### PR TITLE
feat: add option -f/--force for tag command

### DIFF
--- a/src/command/tag.rs
+++ b/src/command/tag.rs
@@ -47,7 +47,7 @@ pub async fn execute(args: TagArgs) {
 }
 
 async fn create_tag(tag_name: &str, message: Option<String>, force: bool) {
-    match tag::create(tag_name, message,force).await {
+    match tag::create(tag_name, message, force).await {
         Ok(_) => (),
         Err(e) => eprintln!("fatal: {}", e),
     }

--- a/src/command/tag.rs
+++ b/src/command/tag.rs
@@ -22,7 +22,7 @@ pub struct TagArgs {
     #[clap(short, long)]
     pub message: Option<String>,
 
-    #[clap(short,long,group="action")]
+    #[clap(short, long, group = "action")]
     pub force: bool,
 
 }
@@ -37,7 +37,7 @@ pub async fn execute(args: TagArgs) {
         if args.delete {
             delete_tag(&name).await;
         } else if args.message.is_some() {
-            create_tag(&name, args.message,args.force).await;
+            create_tag(&name, args.message, args.force).await;
         } else {
             show_tag(&name).await;
         }
@@ -46,7 +46,7 @@ pub async fn execute(args: TagArgs) {
     }
 }
 
-async fn create_tag(tag_name: &str, message: Option<String>,force:bool) {
+async fn create_tag(tag_name: &str, message: Option<String>, force: bool) {
     match tag::create(tag_name, message,force).await {
         Ok(_) => (),
         Err(e) => eprintln!("fatal: {}", e),
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(tags[0].name, "v1.0-annotated");
         assert_eq!(tags[0].object.get_type(), ObjectType::Tag);
 
-        //check message
+        // Check message
         let result = tag::find_tag_and_commit("v1.0-annotated").await;
         assert!(result.is_ok());
         let (object, _) = result.unwrap().unwrap();

--- a/src/internal/tag.rs
+++ b/src/internal/tag.rs
@@ -63,7 +63,7 @@ pub struct Tag {
 ///
 /// * `name` - The name of the tag.
 /// * `message` - If `Some`, creates an annotated tag with the given message. If `None`, creates a lightweight tag.
-pub async fn create(name: &str, message: Option<String>,force:bool) -> Result<(), anyhow::Error> {
+pub async fn create(name: &str, message: Option<String>, force: bool) -> Result<(), anyhow::Error> {
     let head_commit_id = Head::current_commit()
         .await
         .ok_or_else(|| anyhow::anyhow!("Cannot create tag: HEAD does not point to a commit"))?;


### PR DESCRIPTION
为tag指令添加--force参数，添加此参数后，在添加同名tag时，会强制将原tag覆盖，不添加参数则会提示错误

在这里修改了文档 https://github.com/web3infra-foundation/aira/pull/2

close #13 
