### PR TITLE
[r2cn-测试任务] 为 init 命令添加 --object-format 参数 Fixes #32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ target
 # Buck2
 buck-out/
 .buckal/
+
+.libra/

--- a/src/command/clone.rs
+++ b/src/command/clone.rs
@@ -91,6 +91,7 @@ pub async fn execute(args: CloneArgs) {
         quiet: false,
         template: None,
         shared: None,
+        object_format: None,
     };
     command::init::execute(init_args).await;
 

--- a/src/command/reflog.rs
+++ b/src/command/reflog.rs
@@ -198,8 +198,9 @@ fn parse_reflog_selector(selector: &str) -> Option<(&str, usize)> {
     None
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 enum FormatterKind {
+    #[default]
     Oneline,
     Short,
     Medium,
@@ -214,12 +215,6 @@ impl Display for FormatterKind {
             Self::Medium => f.write_str("medium"),
             Self::Full => f.write_str("full"),
         }
-    }
-}
-
-impl Default for FormatterKind {
-    fn default() -> Self {
-        Self::Oneline
     }
 }
 

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -108,6 +108,7 @@ pub async fn setup_with_new_libra_in(temp_path: impl AsRef<Path>) {
         quiet: false,
         template: None,
         shared: None,
+        object_format: None,
     };
     command::init::init(args).await.unwrap();
 }

--- a/tests/command/checkout_test.rs
+++ b/tests/command/checkout_test.rs
@@ -66,6 +66,7 @@ async fn test_checkout_module_functions() {
         quiet: false,
         template: None,
         shared: None,
+        object_format: None,
     };
 
     init::init(init_args)


### PR DESCRIPTION
1. init 命令添加 --object-format 参数
2. 因为--object-format 的加入，需要附带修改修改 clone 文件里对 init结构体的使用
3. 添加对--object-format的测试文件

