### PR TITLE
feat(commit): add --all staging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ achieving unified management.
   - [x] --amend
   - [x] -s, --signoff
   - [x] --disable-pre
-  - [ ] -a, --all
+  - [x] -a, --all
   - [ ] -p, --patch
   - [ ] --no-verify
   - [ ] --no-edit

--- a/src/command/commit.rs
+++ b/src/command/commit.rs
@@ -5,20 +5,21 @@ use std::{collections::HashSet, path::PathBuf};
 
 const EMPTY_TREE_HASH: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
-use crate::command::load_object;
+use crate::command::{load_object, status};
 use crate::common_utils::{check_conventional_commits_message, format_commit_msg};
 use crate::internal::branch::Branch;
 use crate::internal::config::Config as UserConfig;
 use crate::internal::head::Head;
 use crate::internal::reflog::{ReflogAction, ReflogContext, with_reflog};
 use crate::utils::client_storage::ClientStorage;
-use crate::utils::path;
-use crate::utils::util;
+use crate::utils::object_ext::BlobExt;
+use crate::utils::{lfs, path, util};
 use clap::Parser;
 use git_internal::hash::SHA1;
-use git_internal::internal::index::Index;
+use git_internal::internal::index::{Index, IndexEntry};
 use git_internal::internal::object::ObjectTrait;
 use git_internal::internal::object::commit::Commit;
+use git_internal::internal::object::blob::Blob;
 use git_internal::internal::object::tree::{Tree, TreeItem, TreeItemMode};
 use sea_orm::ConnectionTrait;
 use std::process::Command;
@@ -50,14 +51,24 @@ pub struct CommitArgs {
 
     #[arg(long)]
     pub disable_pre: bool,
+
+    /// Automatically stage tracked files that have been modified or deleted
+    #[arg(short = 'a', long)]
+    pub all: bool,
 }
 
 pub async fn execute(args: CommitArgs) {
     /* check args */
+    let auto_stage_applied = if args.all {
+        // Mimic `git commit -a` by staging tracked modifications/deletions first
+        auto_stage_tracked_changes()
+    } else {
+        false
+    };
     let index = Index::load(path::index()).unwrap();
     let storage = ClientStorage::init(path::objects());
     let tracked_entries = index.tracked_entries(0);
-    if tracked_entries.is_empty() && !args.allow_empty {
+    if tracked_entries.is_empty() && !args.allow_empty && !auto_stage_applied {
         panic!("fatal: no changes added to commit, use --allow-empty to override");
     }
 
@@ -261,6 +272,52 @@ pub async fn create_tree(index: &Index, storage: &ClientStorage, current_root: P
     tree
 }
 
+fn auto_stage_tracked_changes() -> bool {
+    let pending = status::changes_to_be_staged();
+    if pending.modified.is_empty() && pending.deleted.is_empty() {
+        return false;
+    }
+
+    let index_path = path::index();
+    let mut index = Index::load(&index_path).unwrap();
+    let workdir = util::working_dir();
+    let mut touched = false;
+
+    for file in pending.modified {
+        let abs = util::workdir_to_absolute(&file);
+        if !abs.exists() {
+            continue;
+        }
+        // Refresh blob IDs for modified tracked files before updating the index
+        let blob = blob_from_file(&abs);
+        blob.save();
+        index
+            .update(IndexEntry::new_from_file(&file, blob.id, &workdir).unwrap());
+        touched = true;
+    }
+
+    for file in pending.deleted {
+        if let Some(path) = file.to_str() {
+            // Drop entries that disappeared from the working tree
+            index.remove(path, 0);
+            touched = true;
+        }
+    }
+
+    if touched {
+        index.save(&index_path).unwrap();
+    }
+    touched
+}
+
+fn blob_from_file(path: impl AsRef<std::path::Path>) -> Blob {
+    if lfs::is_lfs_tracked(&path) {
+        Blob::from_lfs_file(path)
+    } else {
+        Blob::from_file(path)
+    }
+}
+
 /// get current head commit id as parent, if in branch, get branch's commit id, if detached head, get head's commit id
 async fn get_parents_ids() -> Vec<SHA1> {
     // let current_commit_id = reference::Model::current_commit_hash(db).await.unwrap();
@@ -366,6 +423,14 @@ mod test {
         let args = CommitArgs::try_parse_from(["commit", "-m", "init", "--signoff"]);
         assert!(args.is_ok());
         assert!(args.unwrap().signoff);
+
+        let args = CommitArgs::try_parse_from(["commit", "-m", "init", "-a"]);
+        assert!(args.is_ok());
+        assert!(args.unwrap().all);
+
+        let args = CommitArgs::try_parse_from(["commit", "-m", "init", "--all"]);
+        assert!(args.is_ok());
+        assert!(args.unwrap().all);
 
         let args = CommitArgs::try_parse_from(["commit", "-m", "init", "--amend", "--signoff"]);
         assert!(args.is_ok());

--- a/tests/command/branch_test.rs
+++ b/tests/command/branch_test.rs
@@ -19,6 +19,7 @@ async fn test_branch() {
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     };
     commit::execute(commit_args).await;
     let first_commit_id = Branch::find_branch("master", None).await.unwrap().commit;
@@ -31,6 +32,7 @@ async fn test_branch() {
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     };
     commit::execute(commit_args).await;
     let second_commit_id = Branch::find_branch("master", None).await.unwrap().commit;
@@ -118,6 +120,7 @@ async fn test_create_branch_from_remote() {
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     };
     commit::execute(args).await;
     let hash = Head::current_commit().await.unwrap();
@@ -158,6 +161,7 @@ async fn test_invalid_branch_name() {
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     };
     commit::execute(args).await;
 

--- a/tests/command/checkout_test.rs
+++ b/tests/command/checkout_test.rs
@@ -82,6 +82,7 @@ async fn test_checkout_module_functions() {
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     };
     commit::execute(commit_args).await;
 

--- a/tests/command/cherry_pick_test.rs
+++ b/tests/command/cherry_pick_test.rs
@@ -41,6 +41,7 @@ async fn test_basic_cherry_pick() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
     println!("C1: Created common ancestor.");
@@ -76,6 +77,7 @@ async fn test_basic_cherry_pick() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
     println!("C2: Added feature_a.txt on feature branch.");
@@ -106,6 +108,7 @@ async fn test_basic_cherry_pick() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
     println!("C3: Added feature_b.txt on feature branch.");
@@ -238,6 +241,7 @@ async fn test_cherry_pick_with_commit() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -269,6 +273,7 @@ async fn test_cherry_pick_with_commit() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -347,6 +352,7 @@ async fn test_cherry_pick_multiple_commits() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -379,6 +385,7 @@ async fn test_cherry_pick_multiple_commits() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
     let commit1 = Head::current_commit().await.expect("Should have commit1");
@@ -404,6 +411,7 @@ async fn test_cherry_pick_multiple_commits() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
     let commit2 = Head::current_commit().await.expect("Should have commit2");

--- a/tests/command/commit_test.rs
+++ b/tests/command/commit_test.rs
@@ -2,6 +2,7 @@ use serial_test::serial;
 use tempfile::tempdir;
 
 use super::*;
+use libra::utils::object_ext::TreeExt;
 #[tokio::test]
 #[serial]
 #[should_panic]
@@ -21,6 +22,7 @@ async fn test_execute_commit_with_empty_index_fail() {
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     };
     commit::execute(args).await;
 }
@@ -45,6 +47,7 @@ async fn test_execute_commit() {
             amend: false,
             signoff: false,
             disable_pre: true,
+            all: false,
         };
         commit::execute(args).await;
 
@@ -72,6 +75,7 @@ async fn test_execute_commit() {
             amend: true,
             signoff: false,
             disable_pre: true,
+            all: false,
         };
         commit::execute(args).await;
 
@@ -117,6 +121,7 @@ async fn test_execute_commit() {
             amend: false,
             signoff: false,
             disable_pre: true,
+            all: false,
         };
         commit::execute(args).await;
 
@@ -147,6 +152,7 @@ async fn test_execute_commit() {
             amend: true,
             signoff: false,
             disable_pre: true,
+            all: false,
         };
         commit::execute(args).await;
 
@@ -167,4 +173,136 @@ async fn test_execute_commit() {
         let tree: Tree = load_object(&tree_id).unwrap();
         assert_eq!(tree.tree_items.len(), 2); // 2 subtree according to the test data
     }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_commit_with_all_flag_stages_tracked_changes() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    test::ensure_file("tracked.txt", Some("v1"));
+    add::execute(AddArgs {
+        pathspec: vec!["tracked.txt".into()],
+        all: false,
+        update: false,
+        refresh: false,
+        verbose: false,
+        force: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+
+    commit::execute(CommitArgs {
+        message: Some("initial".to_string()),
+        file: None,
+        allow_empty: false,
+        conventional: false,
+        amend: false,
+        signoff: false,
+        disable_pre: true,
+        all: false,
+    })
+    .await;
+
+    test::ensure_file("tracked.txt", Some("updated"));
+    test::ensure_file("new.txt", Some("untracked"));
+
+    commit::execute(CommitArgs {
+        message: Some("with -a".to_string()),
+        file: None,
+        allow_empty: false,
+        conventional: false,
+        amend: false,
+        signoff: false,
+        disable_pre: true,
+        all: true,
+    })
+    .await;
+
+    let head_id = Head::current_commit().await.unwrap();
+    let commit: Commit = load_object(&head_id).unwrap();
+    assert_eq!(commit.message.trim(), "with -a");
+    let tree: Tree = load_object(&commit.tree_id).unwrap();
+    let entries = tree.get_plain_items();
+    let tracked_blob_hash = calc_file_blob_hash("tracked.txt").unwrap();
+    let tracked_entry = entries
+        .iter()
+        .find(|(path, _)| path == &std::path::PathBuf::from("tracked.txt"))
+        .expect("tracked file stored in commit");
+    assert_eq!(tracked_entry.1, tracked_blob_hash);
+    assert!(
+        entries
+            .iter()
+            .all(|(path, _)| path != &std::path::PathBuf::from("new.txt")),
+        "untracked files should not be auto-staged by -a"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_commit_with_all_flag_records_deletions() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    test::ensure_file("keep.txt", Some("keep"));
+    add::execute(AddArgs {
+        pathspec: vec!["keep.txt".into()],
+        all: false,
+        update: false,
+        refresh: false,
+        verbose: false,
+        force: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+
+    commit::execute(CommitArgs {
+        message: Some("baseline".to_string()),
+        file: None,
+        allow_empty: false,
+        conventional: false,
+        amend: false,
+        signoff: false,
+        disable_pre: true,
+        all: false,
+    })
+    .await;
+
+    std::fs::remove_file("keep.txt").unwrap();
+    test::ensure_file("new_untracked.txt", Some("left alone"));
+
+    commit::execute(CommitArgs {
+        message: Some("remove tracked".to_string()),
+        file: None,
+        allow_empty: false,
+        conventional: false,
+        amend: false,
+        signoff: false,
+        disable_pre: true,
+        all: true,
+    })
+    .await;
+
+    let head_id = Head::current_commit().await.unwrap();
+    let commit: Commit = load_object(&head_id).unwrap();
+    assert_eq!(commit.message.trim(), "remove tracked");
+    let tree: Tree = load_object(&commit.tree_id).unwrap();
+    let entries = tree.get_plain_items();
+    assert!(
+        entries
+            .iter()
+            .all(|(path, _)| path != &std::path::PathBuf::from("keep.txt")),
+        "deleted tracked files should be removed from commit"
+    );
+    assert!(
+        entries
+            .iter()
+            .all(|(path, _)| path != &std::path::PathBuf::from("new_untracked.txt")),
+        "new untracked files should still be absent"
+    );
 }

--- a/tests/command/diff_test.rs
+++ b/tests/command/diff_test.rs
@@ -53,6 +53,7 @@ async fn test_basic_diff() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -98,6 +99,7 @@ async fn test_diff_staged() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -160,6 +162,7 @@ async fn test_diff_between_commits() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -189,6 +192,7 @@ async fn test_diff_between_commits() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -242,6 +246,7 @@ async fn test_diff_with_pathspec() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -287,6 +292,7 @@ async fn test_diff_output_to_file() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -348,6 +354,7 @@ async fn test_diff_algorithms() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 

--- a/tests/command/log_test.rs
+++ b/tests/command/log_test.rs
@@ -202,6 +202,7 @@ async fn test_log_patch_no_pathspec() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -226,6 +227,7 @@ async fn test_log_patch_no_pathspec() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -318,6 +320,7 @@ async fn test_log_patch_with_pathspec() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -3,6 +3,7 @@ use git_internal::internal::object::commit::Commit;
 use git_internal::internal::object::tree::Tree;
 use libra::command::branch::BranchArgs;
 use libra::command::branch::execute;
+use libra::command::calc_file_blob_hash;
 use libra::command::get_target_commit;
 use libra::command::init::InitArgs;
 use libra::command::init::init;

--- a/tests/command/rebase_test.rs
+++ b/tests/command/rebase_test.rs
@@ -33,6 +33,7 @@ async fn test_basic_rebase() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -56,6 +57,7 @@ async fn test_basic_rebase() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -88,6 +90,7 @@ async fn test_basic_rebase() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -111,6 +114,7 @@ async fn test_basic_rebase() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -142,6 +146,7 @@ async fn test_basic_rebase() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -214,6 +219,7 @@ async fn test_rebase_already_up_to_date() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -237,6 +243,7 @@ async fn test_rebase_already_up_to_date() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 

--- a/tests/command/reset_test.rs
+++ b/tests/command/reset_test.rs
@@ -28,6 +28,7 @@ async fn setup_standard_repo(temp_path: &std::path::Path) -> (SHA1, SHA1, SHA1, 
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     })
     .await;
     let commit1 = Head::current_commit().await.unwrap();
@@ -62,6 +63,7 @@ async fn setup_standard_repo(temp_path: &std::path::Path) -> (SHA1, SHA1, SHA1, 
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     })
     .await;
     let commit2 = Head::current_commit().await.unwrap();
@@ -96,6 +98,7 @@ async fn setup_standard_repo(temp_path: &std::path::Path) -> (SHA1, SHA1, SHA1, 
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     })
     .await;
     let commit3 = Head::current_commit().await.unwrap();
@@ -130,6 +133,7 @@ async fn setup_standard_repo(temp_path: &std::path::Path) -> (SHA1, SHA1, SHA1, 
         amend: false,
         signoff: false,
         disable_pre: true,
+        all: false,
     })
     .await;
     let commit4 = Head::current_commit().await.unwrap();

--- a/tests/command/revert_test.rs
+++ b/tests/command/revert_test.rs
@@ -42,6 +42,7 @@ async fn test_basic_revert() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
     println!("C1: Added 1.txt");
@@ -67,6 +68,7 @@ async fn test_basic_revert() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
     println!("C2: Modified 1.txt");
@@ -93,6 +95,7 @@ async fn test_basic_revert() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
     println!("C3: Removed 1.txt, Added 2.txt");
@@ -193,6 +196,7 @@ async fn test_revert_no_commit() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -216,6 +220,7 @@ async fn test_revert_no_commit() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -242,6 +247,7 @@ async fn test_revert_no_commit() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 
@@ -278,6 +284,7 @@ async fn test_revert_root_commit() {
         amend: false,
         signoff: false,
         disable_pre: false,
+        all: false,
     })
     .await;
 

--- a/tests/command/switch_test.rs
+++ b/tests/command/switch_test.rs
@@ -45,6 +45,7 @@ async fn test_switch_function() {
             amend: false,
             signoff: false,
             disable_pre: true,
+            all: false,
         };
         commit::execute(args).await;
     }
@@ -89,6 +90,7 @@ async fn test_switch_function() {
             amend: false,
             signoff: false,
             disable_pre: true,
+            all: false,
         };
         commit::execute(args).await;
 
@@ -167,6 +169,7 @@ async fn test_detach_head_basic() {
             amend: false,
             signoff: false,
             disable_pre: true,
+            all: false,
         };
         commit::execute(args).await;
     }
@@ -208,6 +211,7 @@ async fn test_detach_head_basic() {
             amend: false,
             signoff: false,
             disable_pre: true,
+            all: false,
         };
         commit::execute(args).await;
     }


### PR DESCRIPTION
#40 
## Summary
    - add the `-a/--all` flag to `libra commit` so tracked modifications/deletions are auto-staged like `git commit -a`
    - reuse the status diff to refresh blobs/remove entries and adjust the empty-index guard to accept auto-staged deletions
    - cover the behavior with new integration tests (modification + deletion flows) and update README’s command matrix
## Testing
    - cargo test --locked commit_test::test_commit_with_all_flag_stages_tracked_changes
    - cargo test --locked commit_test::test_commit_with_all_flag_records_deletions
    - cargo test --locked commit_test