### PR TITLE
feat(log): add --grep parameter for commit message filtering

### DIFF
--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -205,19 +205,12 @@ pub async fn execute(args: LogArgs) {
     reachable_commits.sort_by(|a, b| b.committer.timestamp.cmp(&a.committer.timestamp));
 
     // Apply grep filtering
-    let filtered_commits = if let Some(pattern) = &args.grep {
-        reachable_commits
+    if let Some(pattern) = &args.grep {
+        reachable_commits = reachable_commits
             .into_iter()
-            .filter(|commit| {
-                commit.message.contains(pattern)
-            })
-            .collect()
-    } else {
-        reachable_commits
-    };
-
-    // Use the filtered commit list
-    let mut reachable_commits = filtered_commits;
+            .filter(|commit| commit.message.contains(pattern))
+            .collect();
+    }
 
     let ref_commits = create_reference_commit_map().await;
 


### PR DESCRIPTION
feat(log): add --grep parameter for commit message filtering
Fixes #47

## 功能描述
为 log 命令添加 `--grep` 参数，允许用户根据提交信息中的内容来过滤提交历史，只显示包含指定模式的提交。

## 实现功能
-  **内容过滤**：基于提交消息的内容进行搜索匹配
-  **模式匹配**：支持简单的字符串包含匹配
-  **参数组合**：可以与其他 log 参数（如 `--oneline`, `-n`, `--stat` 等）组合使用
-  **无结果静默**：当没有匹配的提交时，不输出任何内容

## 实现方案
1. 在 `LogArgs` 结构体中添加 `Option<String>` 类型的 `grep` 字段表示 `--grep` 参数
2. 在获取提交列表后，对每个提交的消息内容进行模式匹配过滤
3. 通过字符串包含匹配实现基础的内容过滤
4. 添加完整的单元测试验证功能正确性

## 测试验证
- 基础 grep 过滤功能
- 大小写敏感匹配
- 无匹配结果静默输出
- 与其他参数组合使用
- 边界情况处理

## 使用示例
```bash
libra log --grep "fix"                    # 显示包含 "fix" 的提交
libra log --grep "feature" --oneline      # 单行显示包含 "feature" 的提交
libra log --grep "test" -n 5              # 显示最多5个包含 "test" 的提交
libra log --grep "nonexistent"            # 无匹配时静默输出