### PR TITLE
test: add test cases for filename conflicts and existing target directories

### DIFF
--- a/tests/command/clone_test.rs
+++ b/tests/command/clone_test.rs
@@ -165,7 +165,7 @@ async fn test_clone_to_existing_dir() {
 #[tokio::test]
 #[serial]
 #[ignore]
-/// Test the clone command in the case where a file with the same name as the target directory already exists.
+/// Test that clone fails when a file exists at the target path.
 async fn test_clone_to_dir_with_existing_file_name() {
     let temp_path = tempdir().unwrap();
     let _guard = test::ChangeDirGuard::new(temp_path.path());
@@ -182,9 +182,11 @@ async fn test_clone_to_dir_with_existing_file_name() {
     })
     .await;
 
-    // Verify that the `.libra` directory does not exist
-    let libra_dir = conflict_path.join(".libra");
-    assert!(!libra_dir.exists());
+    // Verify that the pre-existing file remains a file (clone should not succeed)
+    assert!(
+        conflict_path.is_file(),
+        "pre-existing file should remain a file"
+    );
     // Make sure that the pre-existing file should still exist
     assert!(
         conflict_path.exists(),


### PR DESCRIPTION

Resolve  #79

增加了三个测试用例，覆盖文件名冲突和目标文件夹已存在的边际条件

1. 目标文件夹已存在但为空: test_clone_to_existing_empty_dir
clone命令正确运行，并创建预期的目录结构
2. 目标文件夹存在并且不为空: test_clone_to_existing_dir
clone命令需要终止，不能在目标目录中创建仓库结构，并防止覆盖已有文件
3. 具有与目标文件夹同名的文件: test_clone_to_dir_with_existing_file_name
clone命令能正确处理文件名冲突的情况，且不会覆盖已有同名的文件