### PR TITLE
fix(push): record remote tracking reflog as push (#77)

### DIFF
--- a/src/internal/reflog.rs
+++ b/src/internal/reflog.rs
@@ -71,6 +71,7 @@ impl Display for ReflogContext {
             ),
             ReflogAction::Fetch => write!(f, "fast-forward"),
             ReflogAction::Pull => write!(f, "fast-forward"),
+            ReflogAction::Push => write!(f, "push"),
             ReflogAction::Rebase { state, details } => write!(f, "({state}) {details}"),
             ReflogAction::Clone { from } => write!(f, "from {from}"),
         }
@@ -88,6 +89,7 @@ pub enum ReflogAction {
     Rebase { state: String, details: String },
     Fetch,
     Pull,
+    Push,
     Clone { from: String },
 }
 
@@ -104,6 +106,7 @@ pub enum ReflogActionKind {
     Fetch,
     // pull is a combination of `fetch` and `merge`, maybe we don't need to do anything...
     Pull,
+    Push,
     Clone,
 }
 
@@ -119,6 +122,7 @@ impl Display for ReflogActionKind {
             Self::Rebase => write!(f, "rebase"),
             Self::Fetch => write!(f, "fetch"),
             Self::Pull => write!(f, "pull"),
+            Self::Push => write!(f, "push"),
             Self::Clone => write!(f, "clone"),
         }
     }
@@ -137,6 +141,7 @@ impl ReflogAction {
             Self::Rebase { .. } => ReflogActionKind::Rebase,
             Self::Checkout { .. } => ReflogActionKind::Checkout,
             Self::Fetch => ReflogActionKind::Fetch,
+            Self::Push => ReflogActionKind::Push,
         }
     }
 }

--- a/src/utils/util.rs
+++ b/src/utils/util.rs
@@ -63,11 +63,18 @@ pub fn cur_dir() -> PathBuf {
 pub fn try_get_storage_path(path: Option<PathBuf>) -> Result<PathBuf, io::Error> {
     let mut path = path.clone().unwrap_or_else(cur_dir);
     let orig = path.clone();
+
     loop {
-        let libra = path.join(ROOT_DIR);
-        if libra.exists() {
-            return Ok(libra);
+        let standard_repo = path.join(ROOT_DIR);
+        if standard_repo.exists() {
+            return Ok(standard_repo);
         }
+
+        // Bare repository: database and objects live in the repository root without `.libra`
+        if path.join(DATABASE).exists() && path.join("objects").exists() {
+            return Ok(path);
+        }
+
         if !path.pop() {
             return Err(io::Error::new(
                 io::ErrorKind::NotFound,


### PR DESCRIPTION
fix(push): record remote tracking reflog as push
Fixes #77
## Summary
- 远端跟踪分支 reflog 在 push 成功后记录为 push
- 支持裸仓库路径探测，便于本地裸远端场景
- 补充裸远端 push 测试，校验 reflog 动作为 push

## Testing
- cargo test

## Issue
- #77