### PR TITLE
support bare clone为 clone 命令添加 --bare 参数，克隆仓库时使用 bare 模式

### DIFF
--- a/tests/command/clone_test.rs
+++ b/tests/command/clone_test.rs
@@ -19,6 +19,7 @@ async fn test_clone_branch() {
         local_path: Some(temp_path.path().to_str().unwrap().to_string()),
         branch: Some("dev".to_string()),
         single_branch: false,
+        bare: false,
         depth: None,
     })
     .await;
@@ -39,6 +40,52 @@ async fn test_clone_branch() {
 #[tokio::test]
 #[serial]
 #[ignore]
+/// Test the clone command in bare mode to ensure no working tree is created
+async fn test_clone_bare_repository() {
+    let temp_path = tempdir().unwrap();
+    let _guard = test::ChangeDirGuard::new(temp_path.path());
+
+    let repo_dir = temp_path.path().join("mega-libra-clone-branch-test.git");
+    let remote_url = "https://gitee.com/pikady/mega-libra-clone-branch-test.git".to_string();
+
+    command::clone::execute(CloneArgs {
+        remote_repo: remote_url,
+        local_path: Some(repo_dir.to_str().unwrap().to_string()),
+        branch: Some("dev".to_string()),
+        single_branch: false,
+        bare: true,
+        depth: None,
+    })
+    .await;
+
+    assert!(
+        repo_dir.join("libra.db").exists(),
+        "bare clone should create libra.db at repo root"
+    );
+    assert!(
+        repo_dir.join("info").join("exclude").exists(),
+        "bare clone should create info/exclude at repo root"
+    );
+    assert!(
+        repo_dir.join("objects").exists(),
+        "bare clone should have objects directory at repo root"
+    );
+    assert!(
+        !repo_dir.join(".libra").exists(),
+        "bare clone should not create nested .libra metadata"
+    );
+
+    match Head::current().await {
+        Head::Branch(current_branch) => {
+            assert_eq!(current_branch, "dev");
+        }
+        _ => panic!("bare clone should still update HEAD to a branch"),
+    };
+}
+
+#[tokio::test]
+#[serial]
+#[ignore]
 /// Test the clone command with a specific branch and single branch
 async fn test_clone_branch_single_branch() {
     let temp_path = tempdir().unwrap();
@@ -51,6 +98,7 @@ async fn test_clone_branch_single_branch() {
         local_path: Some(temp_path.path().to_str().unwrap().to_string()),
         branch: Some("dev".to_string()),
         single_branch: true,
+        bare: false,
         depth: None,
     })
     .await;
@@ -85,6 +133,7 @@ async fn test_clone_default_branch() {
         local_path: Some(temp_path.path().to_str().unwrap().to_string()),
         branch: None,
         single_branch: false,
+        bare: false,
         depth: None,
     })
     .await;
@@ -117,6 +166,7 @@ async fn test_clone_default_branch_single_branch() {
         local_path: Some(temp_path.path().to_str().unwrap().to_string()),
         branch: None,
         single_branch: true,
+        bare: false,
         depth: None,
     })
     .await;
@@ -151,6 +201,7 @@ async fn test_clone_empty_repo() {
         local_path: Some(temp_path.path().to_str().unwrap().to_string()),
         branch: None,
         single_branch: false,
+        bare: false,
         depth: None,
     })
     .await;
@@ -185,6 +236,7 @@ async fn test_clone_to_existing_empty_dir() {
         local_path: Some(repo_path.to_str().unwrap().to_string()),
         branch: Some("dev".to_string()),
         single_branch: false,
+        bare: false,
         depth: None,
     })
     .await;
@@ -222,6 +274,7 @@ async fn test_clone_to_existing_dir() {
         local_path: Some(repo_path.to_str().unwrap().to_string()),
         branch: Some("dev".to_string()),
         single_branch: false,
+        bare: false,
         depth: None,
     })
     .await;
@@ -257,6 +310,7 @@ async fn test_clone_to_dir_with_existing_file_name() {
         local_path: Some(conflict_path.to_str().unwrap().to_string()),
         branch: Some("dev".to_string()),
         single_branch: false,
+        bare: false,
         depth: None,
     })
     .await;
@@ -294,6 +348,7 @@ async fn test_clone_with_depth() {
         local_path: Some(temp_path.path().to_str().unwrap().to_string()),
         branch: None,
         single_branch: false,
+        bare: false,
         depth: Some(1),
     })
     .await;
@@ -326,6 +381,7 @@ async fn test_clone_with_depth_and_branch() {
         local_path: Some(temp_path.path().to_str().unwrap().to_string()),
         branch: Some("dev".to_string()),
         single_branch: true,
+        bare: false,
         depth: Some(5),
     })
     .await;


### PR DESCRIPTION
此 PR 完成了 r2cn 测试任务 #174
描述：
支持克隆bare仓库时使用--bare参数，把目标目录直接当作存储根目录
防止status参数扫描bare仓库工作区导致报错
裸仓库不包含工作区，status 不应尝试访问工作区

实现：
增加 bare: bool，解析 --bare 参数。
目标目录检测改为使用 marker 文件(libra.db, info/exclude, object)，裸模式下直接检查目标目录，普通模式则检查(.libra)
初始化：将 bare 参数透传给 (init)，由init 写入 core.bare=true 并跳过 (.libra)
裸仓库路径只写数据库与配置，不执行restore
status等需要工作区的命令在入口处读取 core.bare，若为 true 直接输出error message:fatal: this operation must be run in a work tree并返回。
测试：
tests/command/clone_test.rs::test_clone_bare_repository确认裸克隆目录下存在 (libra.db)(info/exclude), (objects)，且没有 (.libra)
(tests/command/status_test.rs::test_status_rejects_bare_repository)裸仓库环境下运行 status，输出 fatal 提示，确保不会访问不存在的工作区。
手动测试：
libra clone --bare <repo> <dir>
在裸仓库与非裸仓库中分别运行 libra status