### PR TITLE
feat(mv): 新增 mv 命令及完整行为测试

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,8 @@ enum Commands {
     Add(command::add::AddArgs),
     #[command(about = "Remove files from the working tree and from the index")]
     Rm(command::remove::RemoveArgs),
+    #[command(about = "Move or rename a file, a directory, or a symbolic link")]
+    Mv(command::mv::MvArgs),
     #[command(about = "Restore working tree files")]
     Restore(command::restore::RestoreArgs),
     #[command(about = "Show the working tree status")]
@@ -295,6 +297,7 @@ pub async fn parse_async(args: Option<&[&str]>) -> Result<(), GitError> {
         Commands::Rebase(args) => command::rebase::execute(args).await,
         Commands::Merge(args) => command::merge::execute(args).await,
         Commands::Reset(args) => command::reset::execute(args).await,
+        Commands::Mv(args) => command::mv::execute(args).await,
         Commands::CherryPick(args) => command::cherry_pick::execute(args).await,
         Commands::Push(args) => command::push::execute(args).await,
         Commands::IndexPack(args) => command::index_pack::execute(args),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -17,6 +17,7 @@ pub mod init;
 pub mod lfs;
 pub mod log;
 pub mod merge;
+pub mod mv;
 pub mod open;
 pub mod pull;
 pub mod push;

--- a/src/command/mv.rs
+++ b/src/command/mv.rs
@@ -1,0 +1,276 @@
+//! Implementation of `git mv` command, which moves/renames files and directories in the working directory and updates the index accordingly.
+use crate::utils::{path, util};
+use clap::Parser;
+use git_internal::internal::index::Index;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+// use std::env;
+#[derive(Parser, Debug)]
+pub struct MvArgs {
+    /// Path list: one or more <source> followed by <destination>
+    /// The <destination> is required and must be the last argument. It can be either a file or a directory.
+    ///  If there are multiple <source>, the <destination> must be an existing directory.
+    #[clap(required = false)]
+    pub paths: Vec<String>,
+
+    /// more detailed output
+    #[clap(short = 'v', long)]
+    pub verbose: bool,
+
+    /// dry run
+    #[clap(short = 'n', long)]
+    pub dry_run: bool,
+
+    /// Force move/rename even if the destination already exists (overwriting it)
+    #[clap(short = 'f', long)]
+    pub force: bool,
+}
+
+pub async fn execute(args: MvArgs) {
+    if !util::check_repo_exist() {
+        return;
+    }
+    // If the user just types `git mv` without enough arguments, print usage information instead of an error message.
+    if args.paths.len() < 2 {
+        eprintln!("usage: libra mv [<options>] <source>... <destination>");
+        eprintln!();
+        eprintln!("-v, --[no-]verbose    be verbose");
+        eprintln!("-n, --[no-]dry-run    dry run");
+        eprintln!("-f, --[no-]force      force move/rename even if target exists");
+        return;
+    }
+
+    let paths: Vec<PathBuf> = args.paths.iter().map(PathBuf::from).collect();
+    let sources: Vec<PathBuf> = paths[0..paths.len() - 1]
+        .iter()
+        .map(to_absolute_path)
+        .collect();
+    let destination = to_absolute_path(&paths[paths.len() - 1]);
+    // Check if the destination is a directory (if it exists), which affects how we handle multiple sources.
+    let destination_is_dir = destination.is_dir();
+    // If there are multiple sources, the destination must be an existing directory.
+    if sources.len() > 1 && !destination_is_dir {
+        eprintln!(
+            "fatal: destination '{}' is not a directory",
+            util::to_workdir_path(&destination).display()
+        );
+        return;
+    }
+
+    // check the validity of all sources and the destination,
+    // and collect the valid moves to perform.
+    // Report all errors at once without performing any move if there are invalid arguments.
+    let mut valid_moves: Vec<(PathBuf, PathBuf)> = Vec::new();
+    let index_file = path::index();
+    let mut index = Index::load(&index_file).unwrap();
+    for src in &sources {
+        // Check if the source exists before attempting to move it.
+        if !src.exists() {
+            eprintln!(
+                "fatal: bad source, source={}, destination={}",
+                util::to_workdir_path(src).display(),
+                util::to_workdir_path(&destination).display()
+            );
+            return;
+        } else if src == &destination {
+            // Moving a file/directory to itself is not allowed.
+            eprintln!(
+                "fatal: can not move directory into itself, source={}, destination={}",
+                util::to_workdir_path(src).display(),
+                util::to_workdir_path(&destination).display()
+            );
+            return;
+        } else if src.is_dir() {
+            // If the destination is a directory and there is already a directory with the same name as the source in the destination, it's an error
+            if destination.join(src.file_name().unwrap()).exists() && destination_is_dir {
+                eprintln!(
+                    "fatal: destination already exists, source={}, destination={}",
+                    util::to_workdir_path(src).display(),
+                    util::to_workdir_path(&destination).display()
+                );
+                return;
+            } else if !destination.join(src.file_name().unwrap()).exists() && destination_is_dir {
+                // If the source is a directory, we need to check if there are tracked files in the directory and record their moves.
+                match resolve_move_directory(src, &destination, &index) {
+                    Ok(tracked_moves) => {
+                        valid_moves.extend(tracked_moves);
+                    }
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        return;
+                    }
+                }
+            }
+        } else if !index.tracked(&util::path_to_string(&util::to_workdir_path(src)), 0) {
+            // If the source file is not tracked in the index, we consider it an error and do not perform the move.
+            eprintln!(
+                "fatal: not under version control, source={}, destination={}",
+                util::to_workdir_path(src).display(),
+                util::to_workdir_path(&destination).display()
+            );
+            return;
+        } else if is_conflicted_in_index(&index, src) {
+            // If the source file is in conflict in the index, we consider it an error and do not perform the move.
+            eprintln!(
+                "fatal: conflicted, source={}, destination={}",
+                util::to_workdir_path(src).display(),
+                util::to_workdir_path(&destination).display()
+            );
+            return;
+        } else {
+            // Determine the target path for the move.
+            //If the destination is a directory, the target will be destination/src.file_name(),
+            //otherwise it will be the destination itself.
+            let target = if destination_is_dir {
+                destination.join(src.file_name().unwrap())
+            } else {
+                destination.clone()
+            };
+            // If the target already exists, it's an error unless --force is specified.
+            if target.exists() {
+                if !args.force {
+                    eprintln!(
+                        "fatal: destination already exists, source={}, destination={}",
+                        util::to_workdir_path(src).display(),
+                        util::to_workdir_path(&target).display()
+                    );
+                    return;
+                }
+                //only allow overwriting files or symlinks, not directories.
+                if !(target.is_file() || target.is_symlink()) {
+                    eprintln!(
+                        "fatal: Cannot overwrite, source={}, destination={}",
+                        util::to_workdir_path(src).display(),
+                        util::to_workdir_path(&target).display()
+                    );
+                    return;
+                }
+            }
+            valid_moves.push((src.clone(), target));
+        }
+    }
+
+    // Check if there are multiple sources moving to the same target path, which is not allowed.
+    if check_multiple_sources_to_same_target(&sources, &destination) {
+        eprintln!(
+            "fatal: multiple sources moving to the same target path,source={}, destination={}",
+            util::to_workdir_path(&sources[sources.len() - 1]).display(),
+            util::to_workdir_path(&destination).display()
+        );
+        return;
+    }
+    perform_moves(valid_moves, args.verbose, args.dry_run, &mut index).await;
+}
+
+fn to_absolute_path(path: impl AsRef<Path>) -> PathBuf {
+    util::workdir_to_absolute(path.as_ref())
+}
+
+///check if there are tracked files in the source directory
+/// if there are tracked files, we will record the moves of these tracked files,
+///  the move of the directory itself will be handled by filesystem and we don't need to record it.
+fn resolve_move_directory(
+    src: &Path,
+    dst: &Path,
+    index: &Index,
+) -> Result<Vec<(PathBuf, PathBuf)>, String> {
+    let files = util::list_files(src).unwrap();
+    //only consider tracked files for move.
+    //If there are untracked files in the source directory
+    let tracked_moves: Vec<(PathBuf, PathBuf)> = files
+        .into_iter()
+        .filter(|file| index.tracked(&util::path_to_string(file), 0))
+        .map(|file| {
+            let relative_path = util::to_relative(&file, src);
+            (to_absolute_path(&file), dst.join(relative_path))
+        })
+        .collect();
+    // If there are no tracked files in the source directory, we consider it an error and do not perform the move.
+    if tracked_moves.is_empty() {
+        return Err(format!(
+            "fatal: source directory is empty, source={}, destination={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(dst).display()
+        ));
+    }
+    Ok(tracked_moves)
+}
+
+/// Check if the source file is in conflict in the index
+fn is_conflicted_in_index(index: &Index, src: &Path) -> bool {
+    let src_str = util::path_to_string(&util::to_workdir_path(src));
+    (1..=3).any(|stage| index.tracked(&src_str, stage))
+}
+/// Check if there are multiple sources moving to the same target path, which is not allowed.
+fn check_multiple_sources_to_same_target(sources: &[PathBuf], destination: &Path) -> bool {
+    let mut target_paths = HashSet::new();
+    for src in sources {
+        let target = if destination.is_dir() {
+            destination.join(src.file_name().unwrap())
+        } else {
+            destination.to_path_buf()
+        };
+        if !target_paths.insert(target) {
+            return true; // Found a duplicate target path
+        }
+    }
+    false
+}
+
+async fn perform_moves(
+    moves: Vec<(PathBuf, PathBuf)>,
+    verbose: bool,
+    dry_run: bool,
+    index: &mut Index,
+) {
+    let mut moved_any = false;
+    for (src, dst) in moves {
+        //relative path used for index update
+        let src_rel = util::path_to_string(&util::to_workdir_path(&src));
+        let dst_rel = util::path_to_string(&util::to_workdir_path(&dst));
+        // If it's a dry run, we just print the move operations without performing them.
+        if dry_run {
+            println!(
+                "Checking rename of '{}' to '{}'",
+                util::to_workdir_path(&src).display(),
+                util::to_workdir_path(&dst).display()
+            );
+            println!(
+                "Renaming {} to {}",
+                util::to_workdir_path(&src).display(),
+                util::to_workdir_path(&dst).display()
+            );
+            continue;
+        }
+        // Perform the move operation in the filesystem.
+        if let Err(e) = std::fs::rename(&src, &dst) {
+            eprintln!(
+                "fatal: failed to move, source={}, destination={}, error={}",
+                util::to_workdir_path(&src).display(),
+                util::to_workdir_path(&dst).display(),
+                e
+            );
+            return;
+        }
+        // Update the index: remove the old path and add the new path with the same blob hash.
+        if let Some(mut entry) = index.remove(&src_rel, 0) {
+            entry.name = dst_rel.clone();
+            entry.flags.name_length = entry.name.len() as u16;
+            index.add(entry);
+        }
+
+        moved_any = true;
+        // Print the move operation if verbose is enabled.
+        if verbose {
+            println!(
+                "Renaming {} to {}",
+                util::to_workdir_path(&src).display(),
+                util::to_workdir_path(&dst).display()
+            );
+        }
+    }
+    // After performing all moves, save the index if there were any moves.
+    if moved_any && let Err(e) = index.save(path::index()) {
+        eprintln!("fatal: failed to save index after mv: {e}");
+    }
+}

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -15,6 +15,7 @@ use libra::{
         init::{InitArgs, init},
         load_object,
         log::{LogArgs, get_reachable_commits},
+        mv::{self, MvArgs},
         remove::{self, RemoveArgs},
         save_object,
         status::{changes_to_be_committed, changes_to_be_staged},
@@ -44,6 +45,7 @@ mod init_test;
 mod lfs_test;
 mod log_test;
 mod merge_test;
+mod mv_test;
 mod open_test;
 mod pull_test;
 mod push_test;

--- a/tests/command/mv_test.rs
+++ b/tests/command/mv_test.rs
@@ -1,0 +1,273 @@
+//! Integration tests for the mv command covering tracked validation and move behaviors.
+
+use std::fs;
+use std::process::Command;
+
+use super::*;
+
+async fn stage_file(path: &str, content: &str) {
+    test::ensure_file(path, Some(content));
+    add::execute(AddArgs {
+        pathspec: vec![path.to_string()],
+        all: false,
+        update: false,
+        refresh: false,
+        verbose: false,
+        force: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+/// Moves a tracked file to a new file path.
+async fn test_mv_moves_tracked_file_to_new_path() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("a.txt", "hello").await;
+
+    mv::execute(MvArgs {
+        paths: vec!["a.txt".to_string(), "b.txt".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: false,
+    })
+    .await;
+
+    assert!(!temp_path.path().join("a.txt").exists());
+    assert!(temp_path.path().join("b.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Moves a tracked file into an existing destination directory.
+async fn test_mv_moves_tracked_file_into_directory() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("move_me.txt", "content").await;
+    fs::create_dir_all("dest").unwrap();
+
+    mv::execute(MvArgs {
+        paths: vec!["move_me.txt".to_string(), "dest".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: false,
+    })
+    .await;
+
+    assert!(!temp_path.path().join("move_me.txt").exists());
+    assert!(temp_path.path().join("dest/move_me.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Overwrites an existing destination file when `--force` is enabled.
+async fn test_mv_force_overwrites_existing_file() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("src.txt", "new-content").await;
+    test::ensure_file("dst.txt", Some("old-content"));
+
+    mv::execute(MvArgs {
+        paths: vec!["src.txt".to_string(), "dst.txt".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: true,
+    })
+    .await;
+
+    assert!(!temp_path.path().join("src.txt").exists());
+    let dst_content = fs::read_to_string(temp_path.path().join("dst.txt")).unwrap();
+    assert_eq!(dst_content, "new-content");
+}
+
+#[tokio::test]
+#[serial]
+/// Prints a rename message when `-v` is used and move succeeds.
+async fn test_mv_verbose_prints_rename_message() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("verbose.txt", "v").await;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "-v", "verbose.txt", "verbose_new.txt"])
+        .output()
+        .expect("failed to execute libra mv -v");
+
+    assert!(
+        output.status.success(),
+        "mv -v should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Renaming verbose.txt to verbose_new.txt"),
+        "expected verbose output, got stdout: {stdout}"
+    );
+
+    assert!(!temp_path.path().join("verbose.txt").exists());
+    assert!(temp_path.path().join("verbose_new.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Prints dry-run messages exactly as defined in mv implementation.
+async fn test_mv_dry_run_output_matches_command_text() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("dry_cli.txt", "d").await;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "-n", "dry_cli.txt", "dry_cli_new.txt"])
+        .output()
+        .expect("failed to execute libra mv -n");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Checking rename of 'dry_cli.txt' to 'dry_cli_new.txt'"));
+    assert!(stdout.contains("Renaming dry_cli.txt to dry_cli_new.txt"));
+    assert!(temp_path.path().join("dry_cli.txt").exists());
+    assert!(!temp_path.path().join("dry_cli_new.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Prints usage text when `mv` is called without enough arguments.
+async fn test_mv_usage_output_matches_command_text() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv"])
+        .output()
+        .expect("failed to execute libra mv");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("usage: libra mv [<options>] <source>... <destination>"));
+    assert!(stderr.contains("-v, --[no-]verbose    be verbose"));
+    assert!(stderr.contains("-n, --[no-]dry-run    dry run"));
+    assert!(stderr.contains("-f, --[no-]force      force move/rename even if target exists"));
+}
+
+#[tokio::test]
+#[serial]
+/// Prints the expected bad source error text for non-existent source paths.
+async fn test_mv_bad_source_output_matches_command_text() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "11", "22"])
+        .output()
+        .expect("failed to execute libra mv bad source case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("fatal: bad source, source=11, destination=22"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects moving an untracked source file.
+async fn test_mv_rejects_untracked_source() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    test::ensure_file("untracked.txt", Some("u"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "untracked.txt", "renamed.txt"])
+        .output()
+        .expect("failed to execute libra mv untracked case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "fatal: not under version control, source=untracked.txt, destination=renamed.txt"
+        ),
+        "unexpected stderr: {stderr}"
+    );
+
+    assert!(temp_path.path().join("untracked.txt").exists());
+    assert!(!temp_path.path().join("renamed.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects multi-source moves that would map to the same target path.
+async fn test_mv_rejects_multiple_sources_with_same_target_name() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("a/same.txt", "from-a").await;
+    stage_file("b/same.txt", "from-b").await;
+    fs::create_dir_all("dest").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "a/same.txt", "b/same.txt", "dest"])
+        .output()
+        .expect("failed to execute libra mv duplicate target case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "fatal: multiple sources moving to the same target path,source=b/same.txt, destination=dest"
+        ),
+        "unexpected stderr: {stderr}"
+    );
+
+    assert!(temp_path.path().join("a/same.txt").exists());
+    assert!(temp_path.path().join("b/same.txt").exists());
+    assert!(!temp_path.path().join("dest/same.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects moving a directory when it contains no tracked files.
+async fn test_mv_rejects_directory_without_tracked_files() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    fs::create_dir_all("src_dir").unwrap();
+    test::ensure_file("src_dir/untracked.txt", Some("u"));
+    fs::create_dir_all("dest").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "src_dir", "dest"])
+        .output()
+        .expect("failed to execute libra mv empty dir case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("fatal: source directory is empty, source=src_dir, destination=dest"),
+        "unexpected stderr: {stderr}"
+    );
+
+    assert!(temp_path.path().join("src_dir/untracked.txt").exists());
+    assert!(!temp_path.path().join("dest/src_dir").exists());
+}


### PR DESCRIPTION
此 PR 完成了 mv 测试任务 #207 

本 PR 为新增功能：仓库此前没有完整可用的 mv 命令实现。本次新增 mv 命令能力及对应测试集。

功能描述：
新增 mv 命令基础能力：文件重命名、文件移动到目录、多源移动校验、--force 覆盖目标、--verbose 输出、--dry-run 预览执行
新增错误处理：bad source、not under version control、多源同目标冲突、源目录无 tracked 文件

实现方案：
采用“先校验后执行”的流程，避免部分成功导致状态不一致。
统一输出文案并在测试中做输出一致性断言。
成功移动后同步更新 index 条目，保证索引与工作区一致。

