### PR TITLE
Restrict Claude review workflow to trusted users

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,7 +35,14 @@ jobs:
 
     # Run on PRs or when explicitly triggered via comments
     if: |
-          github.event_name == 'pull_request_target' ||
+          (
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.pull_request.author_association == 'OWNER' ||
+              github.event.pull_request.author_association == 'MEMBER' ||
+              github.event.pull_request.author_association == 'COLLABORATOR'
+            )
+          ) ||
           (
             (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
             contains(github.event.comment.body, '@claude')


### PR DESCRIPTION
## Summary
This change enhances the security of the Claude review workflow by restricting automatic reviews on pull requests to only trusted repository members, while maintaining the ability for anyone to request reviews via comments.

## Key Changes
- **Restricted pull_request_target trigger**: Added author association checks to only run automatic Claude reviews when the PR author is an OWNER, MEMBER, or COLLABORATOR of the repository
- **Maintained comment-based reviews**: The workflow still allows any user to request a Claude review by mentioning `@claude` in comments on PRs or issues
- **Added allowed_non_write_users configuration**: Set to `"*"` to permit comment-based review requests from users without write access

## Implementation Details
The condition now uses a logical AND to gate the `pull_request_target` event on author association checks, while keeping the OR condition for comment-based triggers. This prevents potentially malicious PRs from untrusted external contributors from automatically triggering the Claude review action, while still allowing community members to request reviews through comments.

https://claude.ai/code/session_01Wwnn5X7SjGxaAvBerNc4WA