### PR TITLE
feat(mv): implement mv behavior and tests (#207)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,8 @@ enum Commands {
     Merge(command::merge::MergeArgs),
     #[command(about = "Reset current HEAD to specified state")]
     Reset(command::reset::ResetArgs),
+    #[command(about = "Move or rename a file, a directory, or a symlink")]
+    Mv(command::mv::MvArgs),
     #[command(about = "Apply the changes introduced by some existing commits")]
     CherryPick(command::cherry_pick::CherryPickArgs),
     #[command(about = "Update remote refs along with associated objects")]
@@ -295,6 +297,11 @@ pub async fn parse_async(args: Option<&[&str]>) -> Result<(), GitError> {
         Commands::Rebase(args) => command::rebase::execute(args).await,
         Commands::Merge(args) => command::merge::execute(args).await,
         Commands::Reset(args) => command::reset::execute(args).await,
+        Commands::Mv(args) => {
+            command::mv::execute(args)
+                .await
+                .map_err(GitError::CustomError)?;
+        }
         Commands::CherryPick(args) => command::cherry_pick::execute(args).await,
         Commands::Push(args) => command::push::execute(args).await,
         Commands::IndexPack(args) => command::index_pack::execute(args),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -17,6 +17,7 @@ pub mod init;
 pub mod lfs;
 pub mod log;
 pub mod merge;
+pub mod mv;
 pub mod open;
 pub mod pull;
 pub mod push;

--- a/src/command/mv.rs
+++ b/src/command/mv.rs
@@ -1,0 +1,475 @@
+//! Implementation of `git mv` command, which moves/renames files and directories in the working directory and updates the index accordingly.
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+
+use clap::Parser;
+use git_internal::internal::index::{Index, IndexEntry};
+
+use crate::{
+    command::calc_file_blob_hash,
+    utils::{path, util},
+};
+
+#[derive(Parser, Debug)]
+pub struct MvArgs {
+    /// Path list: one or more <source> followed by <destination>
+    /// The <destination> is required and must be the last argument. It can be either a file or a directory.
+    /// If there are multiple <source>, the <destination> must be an existing directory.
+    pub paths: Vec<String>,
+
+    /// Enable verbose output.
+    #[clap(short = 'v', long)]
+    pub verbose: bool,
+
+    /// Perform a dry run.
+    #[clap(short = 'n', long)]
+    pub dry_run: bool,
+
+    /// Force move/rename even if the destination already exists (overwriting it)
+    #[clap(short = 'f', long)]
+    pub force: bool,
+}
+
+#[derive(Default)]
+struct MovePlan {
+    fs_moves: Vec<(PathBuf, PathBuf)>,
+    index_updates: Vec<(PathBuf, PathBuf)>,
+}
+
+impl MovePlan {
+    fn extend(&mut self, mut other: MovePlan) {
+        self.fs_moves.append(&mut other.fs_moves);
+        self.index_updates.append(&mut other.index_updates);
+    }
+}
+
+pub async fn execute(args: MvArgs) -> Result<(), String> {
+    if !util::check_repo_exist() {
+        return Err("fatal: not a libra repository".to_string());
+    }
+    // If the user just types `git mv` without enough arguments, print usage information instead of an error message.
+    if args.paths.len() < 2 {
+        return Err(
+            "usage: libra mv [<options>] <source>... <destination>\n\n-v, --verbose    be verbose\n-n, --dry-run    dry run\n-f, --force      force move/rename even if target exists"
+                .to_string(),
+        );
+    }
+
+    let paths: Vec<PathBuf> = args.paths.iter().map(PathBuf::from).collect();
+    let sources: Vec<PathBuf> = paths[0..paths.len() - 1]
+        .iter()
+        .map(to_absolute_path)
+        .collect();
+    let destination = to_absolute_path(&paths[paths.len() - 1]);
+
+    for src in &sources {
+        validate_path_within_workdir(src)?;
+    }
+    validate_path_within_workdir(&destination)?;
+
+    // Check if the destination is a directory (if it exists), which affects how we handle multiple sources.
+    let destination_is_dir = destination.is_dir();
+    // If there are multiple sources, the destination must be an existing directory.
+    if sources.len() > 1 && !destination_is_dir {
+        return Err(format!(
+            "fatal: destination '{}' is not a directory",
+            util::to_workdir_path(&destination).display()
+        ));
+    }
+
+    // Check the validity of all sources and collect the valid move operations.
+    let mut move_plan = MovePlan::default();
+    let index_file = path::index();
+    let mut index = match Index::load(&index_file) {
+        Ok(index) => index,
+        Err(err) => {
+            return Err(format!("fatal: failed to load index: {err}"));
+        }
+    };
+    for src in &sources {
+        match validate_source_and_collect_moves(
+            src,
+            &destination,
+            destination_is_dir,
+            &index,
+            args.force,
+        ) {
+            Ok(plan) => move_plan.extend(plan),
+            Err(err) => {
+                return Err(err);
+            }
+        }
+    }
+
+    if has_duplicate_target(&move_plan.fs_moves) {
+        return Err(format!(
+            "fatal: multiple sources moving to the same target path, source={}, destination={}",
+            util::to_workdir_path(&sources[sources.len() - 1]).display(),
+            util::to_workdir_path(&destination).display()
+        ));
+    }
+    perform_moves(
+        move_plan,
+        args.verbose,
+        args.dry_run,
+        args.force,
+        &mut index,
+    )
+}
+/// Validates a source path and builds the move plan.
+///
+/// Returns:
+/// - `Ok(MovePlan)`: a move plan with move pairs.
+///   - `fs_moves`: filesystem move pairs `(src_abs, dst_abs)`.
+///   - `index_updates`: index update pairs `(src_abs, dst_abs)`.
+///   - Both source and destination paths in pairs are absolute paths.
+/// - `Err(String)`: a formatted fatal error message for invalid input or unsupported move.
+fn validate_source_and_collect_moves(
+    src: &Path,
+    destination: &Path,
+    destination_is_dir: bool,
+    index: &Index,
+    force: bool,
+) -> Result<MovePlan, String> {
+    if !src.exists() {
+        return Err(format!(
+            "fatal: bad source, source={}, destination={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(destination).display()
+        ));
+    }
+
+    if src == destination {
+        return Err(format!(
+            "fatal: can not move directory into itself, source={}, destination={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(destination).display()
+        ));
+    }
+
+    if src.is_dir() {
+        return validate_source_directory(src, destination, destination_is_dir, index);
+    }
+
+    validate_source_file(src, destination, destination_is_dir, index, force)
+}
+/// Validates a source directory and builds the directory move plan.
+///
+/// Returns:
+/// - `Ok(MovePlan)`: directory move plan where each pair is `(src_abs, dst_abs)`.
+/// - `Err(String)`: a formatted fatal error message.
+fn validate_source_directory(
+    src: &Path,
+    destination: &Path,
+    destination_is_dir: bool,
+    index: &Index,
+) -> Result<MovePlan, String> {
+    // For directory move, we require the destination to be an existing directory
+    if !destination_is_dir {
+        return Err(format!(
+            "fatal: destination '{}' is not a directory",
+            util::to_workdir_path(destination).display()
+        ));
+    }
+
+    let src_name = src.file_name().ok_or_else(|| {
+        format!(
+            "fatal: bad source, source={}, destination={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(destination).display()
+        )
+    })?;
+
+    if destination.starts_with(src) {
+        return Err(format!(
+            "fatal: can not move directory into itself, source={}, destination={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(destination).display()
+        ));
+    }
+
+    if destination.join(src_name).exists() {
+        return Err(format!(
+            "fatal: destination already exists, source={}, destination={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(destination).display()
+        ));
+    }
+
+    resolve_move_directory(src, destination, index)
+}
+/// Validates a source file and builds the file move plan.
+///
+/// Returns:
+/// - `Ok(MovePlan)`: file move plan where each pair is `(src_abs, dst_abs)`.
+/// - `Err(String)`: a formatted fatal error message.
+fn validate_source_file(
+    src: &Path,
+    destination: &Path,
+    destination_is_dir: bool,
+    index: &Index,
+    force: bool,
+) -> Result<MovePlan, String> {
+    if !index.tracked(&util::path_to_string(&util::to_workdir_path(src)), 0) {
+        return Err(format!(
+            "fatal: not under version control, source={}, destination={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(destination).display()
+        ));
+    }
+
+    if is_conflicted_in_index(index, src) {
+        return Err(format!(
+            "fatal: conflicted, source={}, destination={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(destination).display()
+        ));
+    }
+
+    let target = if destination_is_dir {
+        let src_name = src.file_name().ok_or_else(|| {
+            format!(
+                "fatal: bad source, source={}, destination={}",
+                util::to_workdir_path(src).display(),
+                util::to_workdir_path(destination).display()
+            )
+        })?;
+        destination.join(src_name)
+    } else {
+        destination.to_path_buf()
+    };
+
+    if let Ok(meta) = std::fs::symlink_metadata(&target) {
+        if !force {
+            return Err(format!(
+                "fatal: destination already exists, source={}, destination={}",
+                util::to_workdir_path(src).display(),
+                util::to_workdir_path(&target).display()
+            ));
+        }
+        let file_type = meta.file_type();
+        if !(file_type.is_file() || file_type.is_symlink()) {
+            return Err(format!(
+                "fatal: cannot overwrite, source={}, destination={}",
+                util::to_workdir_path(src).display(),
+                util::to_workdir_path(&target).display()
+            ));
+        }
+    }
+
+    Ok(MovePlan {
+        fs_moves: vec![(src.to_path_buf(), target.clone())],
+        index_updates: vec![(src.to_path_buf(), target)],
+    })
+}
+
+fn to_absolute_path(path: impl AsRef<Path>) -> PathBuf {
+    let workdir_relative = util::to_workdir_path(path.as_ref());
+    util::workdir_to_absolute(workdir_relative)
+}
+
+fn validate_path_within_workdir(path: &Path) -> Result<(), String> {
+    let workdir = util::working_dir();
+    if !util::is_sub_path(path, &workdir) {
+        return Err(format!(
+            "fatal: '{}' is outside of the repository at '{}'",
+            path.display(),
+            workdir.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Builds a move plan for a directory source.
+/// - Moves the whole directory in the filesystem (tracked + untracked + empty dirs).
+/// - Updates the index only for tracked files under the source directory.
+/// - Untracked files are moved with the directory rename and are not added to the index.
+///
+/// Returns:
+/// - `Ok(MovePlan)`: move plan with absolute-path pairs `(src_abs, dst_abs)`.
+/// - `Err(String)`: a formatted fatal error message.
+fn resolve_move_directory(src: &Path, dst: &Path, index: &Index) -> Result<MovePlan, String> {
+    let src_name = src.file_name().ok_or_else(|| {
+        format!(
+            "fatal: bad source, source={}, destination={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(dst).display()
+        )
+    })?;
+    let target_dir = dst.join(src_name);
+
+    let files = util::list_files(src).map_err(|err| {
+        format!(
+            "fatal: failed to list source directory, source={}, destination={}, error={}",
+            util::to_workdir_path(src).display(),
+            util::to_workdir_path(dst).display(),
+            err
+        )
+    })?;
+
+    let tracked_updates: Vec<(PathBuf, PathBuf)> = files
+        .into_iter()
+        .filter(|file| index.tracked(&util::path_to_string(file), 0))
+        .map(|file| {
+            let relative_path = util::to_relative(&file, src);
+            (
+                util::workdir_to_absolute(&file),
+                util::workdir_to_absolute(target_dir.join(relative_path)),
+            )
+        })
+        .collect();
+
+    Ok(MovePlan {
+        fs_moves: vec![(src.to_path_buf(), target_dir)],
+        index_updates: tracked_updates,
+    })
+}
+
+/// Checks whether the source file is conflicted in the index.
+fn is_conflicted_in_index(index: &Index, src: &Path) -> bool {
+    let src_str = util::path_to_string(&util::to_workdir_path(src));
+    (1..=3).any(|stage| index.tracked(&src_str, stage))
+}
+/// Checks whether multiple move operations target the same destination path.
+fn has_duplicate_target(moves: &[(PathBuf, PathBuf)]) -> bool {
+    let mut target_paths = HashSet::new();
+    for (_, target) in moves {
+        if !target_paths.insert(target.clone()) {
+            return true;
+        }
+    }
+    false
+}
+
+fn remove_index_entry_all_stages(index: &mut Index, path: &str) {
+    for stage in 0..=3 {
+        let _ = index.remove(path, stage);
+    }
+}
+
+fn perform_moves(
+    plan: MovePlan,
+    verbose: bool,
+    dry_run: bool,
+    force: bool,
+    index: &mut Index,
+) -> Result<(), String> {
+    let mut moved_count = 0usize;
+
+    for (src, dst) in &plan.fs_moves {
+        let src_workdir = util::to_workdir_path(src);
+        let dst_workdir = util::to_workdir_path(dst);
+
+        // If it's a dry run, we just print the move operations without performing them.
+        if dry_run {
+            println!(
+                "Checking rename of '{}' to '{}'",
+                src_workdir.display(),
+                dst_workdir.display()
+            );
+            println!(
+                "Renaming {} to {}",
+                src_workdir.display(),
+                dst_workdir.display()
+            );
+            continue;
+        }
+        // For actual move, we first check if the parent directory of the destination exists, if not, we try to create it.
+        if let Some(parent) = dst.parent()
+            && let Err(err) = std::fs::create_dir_all(parent)
+        {
+            return Err(format!(
+                "fatal: failed to create destination directory, source={}, destination={}, error={}",
+                src_workdir.display(),
+                dst_workdir.display(),
+                err
+            ));
+        }
+
+        if force && let Ok(meta) = std::fs::symlink_metadata(dst) {
+            let file_type = meta.file_type();
+            if (file_type.is_file() || file_type.is_symlink())
+                && let Err(err) = std::fs::remove_file(dst)
+            {
+                return Err(format!(
+                    "fatal: failed to remove destination before force move, source={}, destination={}, error={}",
+                    src_workdir.display(),
+                    dst_workdir.display(),
+                    err
+                ));
+            }
+        }
+
+        // Perform the move operation in the filesystem.
+        if let Err(e) = std::fs::rename(src, dst) {
+            return Err(format!(
+                "fatal: failed to move, source={}, destination={}, error={}",
+                src_workdir.display(),
+                dst_workdir.display(),
+                e
+            ));
+        }
+
+        moved_count += 1;
+
+        // Print the move operation if verbose is enabled.
+        if verbose {
+            println!(
+                "Renaming {} to {}",
+                src_workdir.display(),
+                dst_workdir.display()
+            );
+        }
+    }
+
+    if dry_run {
+        return Ok(());
+    }
+
+    // Update index only after all filesystem moves succeeded.
+    for (src, dst) in &plan.index_updates {
+        let src_rel = util::path_to_string(&util::to_workdir_path(src));
+        let dst_workdir = util::to_workdir_path(dst);
+        let dst_rel = util::path_to_string(&dst_workdir);
+
+        remove_index_entry_all_stages(index, &dst_rel);
+
+        if index.remove(&src_rel, 0).is_some() {
+            let new_entry = calc_file_blob_hash(dst)
+                .map_err(|err| {
+                    format!(
+                        "failed to calculate hash for moved file, source={}, destination={}, error={}",
+                        src_rel, dst_rel, err
+                    )
+                })
+                .and_then(|hash| {
+                    IndexEntry::new_from_file(&dst_workdir, hash, &util::working_dir()).map_err(
+                        |err| {
+                            format!(
+                                "failed to build index entry for moved file, source={}, destination={}, error={}",
+                                src_rel, dst_rel, err
+                            )
+                        },
+                    )
+                });
+
+            match new_entry {
+                Ok(entry) => index.add(entry),
+                Err(err) => {
+                    return Err(format!("fatal: {err}"));
+                }
+            }
+        }
+    }
+
+    // After performing all moves, save the index if there were any moves.
+    if moved_count > 0
+        && let Err(e) = index.save(path::index())
+    {
+        return Err(format!("fatal: failed to save index after mv: {e}"));
+    }
+
+    Ok(())
+}

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -15,6 +15,7 @@ use libra::{
         init::{InitArgs, init},
         load_object,
         log::{LogArgs, get_reachable_commits},
+        mv::{self, MvArgs},
         remove::{self, RemoveArgs},
         save_object,
         status::{changes_to_be_committed, changes_to_be_staged},
@@ -44,6 +45,7 @@ mod init_test;
 mod lfs_test;
 mod log_test;
 mod merge_test;
+mod mv_test;
 mod open_test;
 mod pull_test;
 mod push_test;

--- a/tests/command/mv_test.rs
+++ b/tests/command/mv_test.rs
@@ -1,0 +1,604 @@
+//! Integration tests for the mv command covering tracked validation and move behaviors.
+
+use std::{fs, process::Command};
+
+use git_internal::internal::index::{Index, IndexEntry};
+use libra::utils::path;
+
+use super::*;
+
+async fn stage_file(path: &str, content: &str) {
+    test::ensure_file(path, Some(content));
+    add::execute(AddArgs {
+        pathspec: vec![path.to_string()],
+        all: false,
+        update: false,
+        refresh: false,
+        verbose: false,
+        force: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+/// Moves a tracked file to a new file path.
+async fn test_mv_moves_tracked_file_to_new_path() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("a.txt", "hello").await;
+
+    let result = mv::execute(MvArgs {
+        paths: vec!["a.txt".to_string(), "b.txt".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: false,
+    })
+    .await;
+    assert!(result.is_ok());
+
+    assert!(!temp_path.path().join("a.txt").exists());
+    assert!(temp_path.path().join("b.txt").exists());
+
+    let index = Index::load(path::index()).unwrap();
+    assert!(!index.tracked("a.txt", 0));
+    assert!(index.tracked("b.txt", 0));
+}
+
+#[tokio::test]
+#[serial]
+/// Moves a tracked file into an existing destination directory.
+async fn test_mv_moves_tracked_file_into_directory() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("move_me.txt", "content").await;
+    fs::create_dir_all("dest").unwrap();
+
+    let result = mv::execute(MvArgs {
+        paths: vec!["move_me.txt".to_string(), "dest".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: false,
+    })
+    .await;
+    assert!(result.is_ok());
+
+    assert!(!temp_path.path().join("move_me.txt").exists());
+    assert!(temp_path.path().join("dest/move_me.txt").exists());
+
+    let index = Index::load(path::index()).unwrap();
+    assert!(!index.tracked("move_me.txt", 0));
+    assert!(index.tracked("dest/move_me.txt", 0));
+}
+
+#[tokio::test]
+#[serial]
+/// Resolves mv path arguments relative to current directory when invoked from a subdirectory.
+async fn test_mv_resolves_paths_from_current_subdirectory() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("sub/a.txt", "content").await;
+
+    let _sub_guard = ChangeDirGuard::new(temp_path.path().join("sub"));
+    let result = mv::execute(MvArgs {
+        paths: vec!["a.txt".to_string(), "b.txt".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: false,
+    })
+    .await;
+
+    assert!(result.is_ok());
+    assert!(!temp_path.path().join("sub/a.txt").exists());
+    assert!(temp_path.path().join("sub/b.txt").exists());
+
+    let index = Index::load(path::index()).unwrap();
+    assert!(!index.tracked("sub/a.txt", 0));
+    assert!(index.tracked("sub/b.txt", 0));
+}
+
+#[tokio::test]
+#[serial]
+/// Moves a directory with tracked files and updates index entries for moved files.
+async fn test_mv_moves_directory_with_tracked_files() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("src_dir/a.txt", "a").await;
+    stage_file("src_dir/sub/b.txt", "b").await;
+    fs::create_dir_all("dest").unwrap();
+
+    let result = mv::execute(MvArgs {
+        paths: vec!["src_dir".to_string(), "dest".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: false,
+    })
+    .await;
+    assert!(result.is_ok());
+
+    assert!(!temp_path.path().join("src_dir/a.txt").exists());
+    assert!(!temp_path.path().join("src_dir/sub/b.txt").exists());
+    assert!(temp_path.path().join("dest/src_dir/a.txt").exists());
+    assert!(temp_path.path().join("dest/src_dir/sub/b.txt").exists());
+
+    let index = Index::load(path::index()).unwrap();
+    assert!(!index.tracked("src_dir/a.txt", 0));
+    assert!(!index.tracked("src_dir/sub/b.txt", 0));
+    assert!(index.tracked("dest/src_dir/a.txt", 0));
+    assert!(index.tracked("dest/src_dir/sub/b.txt", 0));
+}
+
+#[tokio::test]
+#[serial]
+/// When force-overwriting an already tracked destination, index should keep only the renamed destination entry.
+async fn test_mv_force_overwrites_tracked_destination_and_replaces_index_entry() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("src.txt", "new-content").await;
+    stage_file("dst.txt", "old-content").await;
+
+    let result = mv::execute(MvArgs {
+        paths: vec!["src.txt".to_string(), "dst.txt".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: true,
+    })
+    .await;
+    assert!(result.is_ok());
+
+    assert!(!temp_path.path().join("src.txt").exists());
+    let dst_content = fs::read_to_string(temp_path.path().join("dst.txt")).unwrap();
+    assert_eq!(dst_content, "new-content");
+
+    let index = Index::load(path::index()).unwrap();
+    assert!(!index.tracked("src.txt", 0));
+    assert!(index.tracked("dst.txt", 0));
+}
+
+#[tokio::test]
+#[serial]
+/// Refreshes destination index metadata/hash by rebuilding the entry from the moved file.
+async fn test_mv_rebuilds_index_entry_from_destination_file() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("src.txt", "actual-src-content").await;
+    stage_file("other.txt", "different-content").await;
+
+    let mut index = Index::load(path::index()).unwrap();
+    let stale_hash = index.get("other.txt", 0).unwrap().hash;
+    let mut src_entry = index.remove("src.txt", 0).unwrap();
+    src_entry.hash = stale_hash;
+    index.add(src_entry);
+    index.save(path::index()).unwrap();
+
+    let result = mv::execute(MvArgs {
+        paths: vec!["src.txt".to_string(), "dst.txt".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: false,
+    })
+    .await;
+    assert!(result.is_ok());
+
+    let index = Index::load(path::index()).unwrap();
+    let dst_entry_hash = index.get("dst.txt", 0).unwrap().hash;
+    let expected_hash = calc_file_blob_hash(temp_path.path().join("dst.txt")).unwrap();
+
+    assert_eq!(dst_entry_hash, expected_hash);
+}
+
+#[tokio::test]
+#[serial]
+/// Prints a rename message when `-v` is used and move succeeds.
+async fn test_mv_verbose_prints_rename_message() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("verbose.txt", "v").await;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "-v", "verbose.txt", "verbose_new.txt"])
+        .output()
+        .expect("failed to execute libra mv -v");
+
+    assert!(
+        output.status.success(),
+        "mv -v should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Renaming verbose.txt to verbose_new.txt"),
+        "expected verbose output, got stdout: {stdout}"
+    );
+
+    assert!(!temp_path.path().join("verbose.txt").exists());
+    assert!(temp_path.path().join("verbose_new.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Prints dry-run messages exactly as defined in mv implementation.
+async fn test_mv_dry_run_output_matches_command_text() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("dry_cli.txt", "d").await;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "-n", "dry_cli.txt", "dry_cli_new.txt"])
+        .output()
+        .expect("failed to execute libra mv -n");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Checking rename of 'dry_cli.txt' to 'dry_cli_new.txt'"));
+    assert!(stdout.contains("Renaming dry_cli.txt to dry_cli_new.txt"));
+    assert!(temp_path.path().join("dry_cli.txt").exists());
+    assert!(!temp_path.path().join("dry_cli_new.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Prints usage text when `mv` is called without enough arguments.
+async fn test_mv_usage_output_matches_command_text() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv"])
+        .output()
+        .expect("failed to execute libra mv");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("usage: libra mv [<options>] <source>... <destination>"));
+    assert!(stderr.contains("-v, --verbose    be verbose"));
+    assert!(stderr.contains("-n, --dry-run    dry run"));
+    assert!(stderr.contains("-f, --force      force move/rename even if target exists"));
+}
+
+#[tokio::test]
+#[serial]
+/// Prints the expected bad source error text for non-existent source paths.
+async fn test_mv_bad_source_output_matches_command_text() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "11", "22"])
+        .output()
+        .expect("failed to execute libra mv bad source case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("fatal: bad source, source=11, destination=22"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects source paths that escape repository boundary.
+async fn test_mv_rejects_source_path_outside_workdir() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    let outside_src = temp_path
+        .path()
+        .parent()
+        .unwrap()
+        .join("mv_outside_src.txt");
+    fs::write(&outside_src, "x").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "../mv_outside_src.txt", "renamed.txt"])
+        .output()
+        .expect("failed to execute libra mv outside-source case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("is outside of the repository at"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(outside_src.exists());
+    assert!(!temp_path.path().join("renamed.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects destination paths that escape repository boundary.
+async fn test_mv_rejects_destination_path_outside_workdir() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("inside.txt", "x").await;
+    let outside_dst = temp_path
+        .path()
+        .parent()
+        .unwrap()
+        .join("mv_outside_dst.txt");
+    if outside_dst.exists() {
+        fs::remove_file(&outside_dst).unwrap();
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "inside.txt", "../mv_outside_dst.txt"])
+        .output()
+        .expect("failed to execute libra mv outside-destination case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("is outside of the repository at"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(temp_path.path().join("inside.txt").exists());
+    assert!(!outside_dst.exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects moving an untracked source file.
+async fn test_mv_rejects_untracked_source() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    test::ensure_file("untracked.txt", Some("u"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "untracked.txt", "renamed.txt"])
+        .output()
+        .expect("failed to execute libra mv untracked case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "fatal: not under version control, source=untracked.txt, destination=renamed.txt"
+        ),
+        "unexpected stderr: {stderr}"
+    );
+
+    assert!(temp_path.path().join("untracked.txt").exists());
+    assert!(!temp_path.path().join("renamed.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects moving a path that is in conflicted (unmerged) index state.
+async fn test_mv_rejects_conflicted_source_file() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("conflict.txt", "base").await;
+
+    let mut index = Index::load(path::index()).unwrap();
+    let (stage0_hash, stage0_size) = {
+        let stage0 = index
+            .get("conflict.txt", 0)
+            .expect("conflict.txt should be present at stage 0 before conflict setup");
+        (stage0.hash, stage0.size)
+    };
+
+    for stage in 1..=3 {
+        let mut entry =
+            IndexEntry::new_from_blob("conflict.txt".to_string(), stage0_hash, stage0_size);
+        entry.flags.stage = stage;
+        index.add(entry);
+    }
+    index
+        .save(path::index())
+        .expect("failed to save conflict index entries");
+
+    let index = Index::load(path::index()).unwrap();
+    assert!(index.tracked("conflict.txt", 0));
+    assert!((1..=3).all(|stage| index.tracked("conflict.txt", stage)));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "conflict.txt", "renamed.txt"])
+        .output()
+        .expect("failed to execute libra mv conflict case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("fatal: conflicted, source=conflict.txt, destination=renamed.txt"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(temp_path.path().join("conflict.txt").exists());
+    assert!(!temp_path.path().join("renamed.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects multi-source moves that would map to the same target path.
+async fn test_mv_rejects_multiple_sources_with_same_target_name() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("a/same.txt", "from-a").await;
+    stage_file("b/same.txt", "from-b").await;
+    fs::create_dir_all("dest").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "a/same.txt", "b/same.txt", "dest"])
+        .output()
+        .expect("failed to execute libra mv duplicate target case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "fatal: multiple sources moving to the same target path, source=b/same.txt, destination=dest"
+        ),
+        "unexpected stderr: {stderr}"
+    );
+
+    assert!(temp_path.path().join("a/same.txt").exists());
+    assert!(temp_path.path().join("b/same.txt").exists());
+    assert!(!temp_path.path().join("dest/same.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Moves a directory even when it contains only untracked files.
+async fn test_mv_moves_directory_without_tracked_files() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    fs::create_dir_all("src_dir").unwrap();
+    test::ensure_file("src_dir/untracked.txt", Some("u"));
+    fs::create_dir_all("dest").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "src_dir", "dest"])
+        .output()
+        .expect("failed to execute libra mv untracked-only directory case");
+
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).is_empty(),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(!temp_path.path().join("src_dir/untracked.txt").exists());
+    assert!(temp_path.path().join("dest/src_dir/untracked.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Moves tracked and untracked files together for directory sources, but updates index only for tracked paths.
+async fn test_mv_moves_mixed_directory_and_updates_only_tracked_index_entries() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("src_dir/tracked.txt", "t").await;
+    test::ensure_file("src_dir/untracked.txt", Some("u"));
+    fs::create_dir_all("dest").unwrap();
+
+    let result = mv::execute(MvArgs {
+        paths: vec!["src_dir".to_string(), "dest".to_string()],
+        verbose: false,
+        dry_run: false,
+        force: false,
+    })
+    .await;
+    assert!(result.is_ok());
+
+    assert!(temp_path.path().join("dest/src_dir/tracked.txt").exists());
+    assert!(temp_path.path().join("dest/src_dir/untracked.txt").exists());
+
+    let index = Index::load(path::index()).unwrap();
+    assert!(!index.tracked("src_dir/tracked.txt", 0));
+    assert!(index.tracked("dest/src_dir/tracked.txt", 0));
+    assert!(!index.tracked("dest/src_dir/untracked.txt", 0));
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects moving a directory to a non-directory destination path.
+async fn test_mv_rejects_directory_to_non_directory_destination() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("dir/x.txt", "x").await;
+    test::ensure_file("dest_file.txt", Some("d"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "dir", "dest_file.txt"])
+        .output()
+        .expect("failed to execute libra mv directory->file case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("fatal: destination 'dest_file.txt' is not a directory"),
+        "unexpected stderr: {stderr}"
+    );
+
+    assert!(temp_path.path().join("dir/x.txt").exists());
+    assert!(temp_path.path().join("dest_file.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects moves where source and destination are the same path.
+async fn test_mv_rejects_same_source_and_destination_path() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    test::ensure_file("same.txt", Some("x"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "same.txt", "same.txt"])
+        .output()
+        .expect("failed to execute libra mv same-path case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "fatal: can not move directory into itself, source=same.txt, destination=same.txt"
+        ),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+/// Rejects moving a directory into its own subdirectory.
+async fn test_mv_rejects_moving_directory_into_subdirectory() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    stage_file("dir/file.txt", "x").await;
+    fs::create_dir_all("dir/sub").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .args(["mv", "dir", "dir/sub"])
+        .output()
+        .expect("failed to execute libra mv directory-into-subdirectory case");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr
+            .contains("fatal: can not move directory into itself, source=dir, destination=dir/sub"),
+        "unexpected stderr: {stderr}"
+    );
+
+    assert!(temp_path.path().join("dir/file.txt").exists());
+}


### PR DESCRIPTION
此 PR 完成了 mv 测试任务 https://github.com/web3infra-foundation/libra/issues/207

本 PR 为新增功能：仓库此前没有完整可用的 mv 命令实现。本次新增 mv 命令能力及对应测试集。

功能描述：
新增 mv 命令基础能力：文件重命名、文件移动到目录、多源移动校验、--force 覆盖目标、--verbose 输出、--dry-run 预览执行
新增错误处理：bad source、not under version control、多源同目标冲突、源目录无 tracked 文件

实现方案：
采用“先校验后执行”的流程，避免部分成功导致状态不一致。
统一输出文案并在测试中做输出一致性断言。
成功移动后同步更新 index 条目，保证索引与工作区一致。