### PR TITLE
fix(agent-codex): deduplicate console replies and clean up agent response markers

### DIFF
--- a/src/command/agent_codex/mod.rs
+++ b/src/command/agent_codex/mod.rs
@@ -2434,11 +2434,7 @@ Task Completed"
                                                         .and_then(|t| t.as_str())
                                                         .unwrap_or("")
                                                         .to_string();
-                                                    println!(
-                                                        "
-  ?? Agent Response started
-"
-                                                    );
+                                                    println!("Agent Response started");
 
                                                     let msg = AgentMessage {
                                                         id: item_id.clone(),
@@ -3431,25 +3427,39 @@ Task Completed"
                                                         .and_then(|t| t.as_str())
                                                         .unwrap_or("")
                                                         .to_string();
-                                                    if let Some(mut session) = lock_or_warn(
-                                                        &session_clone,
-                                                        "agent message completed update",
-                                                    ) && let Some(msg) = session
-                                                        .agent_messages
-                                                        .iter_mut()
-                                                        .find(|m| m.id == item_id)
+                                                    let previous_content = if let Some(mut session) =
+                                                        lock_or_warn(
+                                                            &session_clone,
+                                                            "agent message completed update",
+                                                        )
+                                                        && let Some(msg) = session
+                                                            .agent_messages
+                                                            .iter_mut()
+                                                            .find(|m| m.id == item_id)
                                                     {
+                                                        let previous_content = msg.content.clone();
                                                         msg.content = content.clone();
-                                                        if !msg.content.is_empty() {
-                                                            println!(
-                                                                "
-                                                                ?? Agent: {}
-                                                                ",
-                                                                msg.content
-                                                            );
+                                                        previous_content
+                                                    } else {
+                                                        String::new()
+                                                    };
+                                                    if !content.is_empty() {
+                                                        if previous_content.is_empty() {
+                                                            println!("Agent: {}", content);
+                                                        } else if let Some(suffix) =
+                                                            content.strip_prefix(&previous_content)
+                                                        {
+                                                            if !suffix.is_empty() {
+                                                                print!("{}", suffix);
+                                                                if !content.ends_with('\n') {
+                                                                    println!();
+                                                                }
+                                                            }
+                                                        } else {
+                                                            println!("Agent: {}", content);
                                                         }
                                                     }
-                                                    println!("  ?? Agent Response completed");
+                                                    println!("Agent Response completed");
                                                 }
                                                 _ => {}
                                             }


### PR DESCRIPTION
## Summary

Demo video (recorded by me): https://youtu.be/w51jOlm2vrI  
The video shows how `agent-codex` works end-to-end and is not limited to the changes in this PR.

Fix duplicate agent reply rendering in `agent-codex` console output and remove garbled `??` markers from agent response logs.

## What Changed

- Prevent the completed `agentMessage` event from printing the full reply again when the text was already streamed through `AgentMessageDelta`
- Only print the missing suffix on completion if the streamed delta output was partial
- Normalize agent response lifecycle messages by replacing garbled `??` output with readable text:
  - `Agent Response started`
  - `Agent: ...`
  - `Agent Response completed`

## Why

`agent-codex` was rendering agent replies twice in the terminal:
- once during streaming delta output
- again when the final completed item arrived

This made interactive output noisy and confusing. Some lifecycle messages were also displayed with corrupted `??` markers, which reduced readability.

## Result

Terminal output for agent replies is now cleaner and easier to follow:
- no duplicated final reply
- readable agent response markers
- streamed output remains intact