### PR TITLE
feat(log): add --grep parameter for commit message filtering

### DIFF
--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -127,6 +127,7 @@ struct CommitFilter {
     since: Option<i64>,
     until: Option<i64>,
     paths: Vec<PathBuf>,
+    grep: Option<String>,
 }
 
 impl CommitFilter {
@@ -135,12 +136,14 @@ impl CommitFilter {
         since: Option<i64>,
         until: Option<i64>,
         paths: Vec<PathBuf>,
+        grep: Option<String>,
     ) -> Self {
         Self {
             author: author.map(|s| s.to_lowercase()),
             since,
             until,
             paths,
+            grep,
         }
     }
 
@@ -166,6 +169,12 @@ impl CommitFilter {
             && ts > until
         {
             return false;
+        }
+
+        if let Some(pattern) = &self.grep {
+            if !pattern.is_empty() && !commit.message.contains(pattern.as_str()) {
+                return false;
+            }
         }
 
         true
@@ -348,7 +357,13 @@ pub async fn execute_safe(args: LogArgs, output: &OutputConfig) -> CliResult<()>
         .transpose()
         .map_err(|e| CliError::fatal(e.to_string()))?;
     let path_filters: Vec<PathBuf> = args.pathspec.iter().map(util::to_workdir_path).collect();
-    let filter = CommitFilter::new(args.author.clone(), since, until, path_filters.clone());
+    let filter = CommitFilter::new(
+        args.author.clone(),
+        since,
+        until,
+        path_filters.clone(),
+        args.grep.clone(),
+    );
 
     let decorate_option = determine_decorate_option(&args)
         .await
@@ -383,18 +398,19 @@ pub async fn execute_safe(args: LogArgs, output: &OutputConfig) -> CliResult<()>
         .to_string();
 
     let mut reachable_commits = get_reachable_commits(commit_hash.clone(), None).await?;
-    // default sort with signature time
-    reachable_commits.sort_by_key(|b| std::cmp::Reverse(b.committer.timestamp));
 
-    // Apply grep filtering
+    // Save full history for abbreviation length calculation (before filtering)
+    let full_history = reachable_commits.clone();
+
+    // Apply grep filtering before sorting (more efficient)
     if let Some(pattern) = &args.grep {
         if !pattern.is_empty() {
-            reachable_commits = reachable_commits
-                .into_iter()
-                .filter(|commit| commit.message.contains(pattern))
-                .collect();
+            reachable_commits.retain(|commit| commit.message.contains(pattern));
         }
     }
+
+    // default sort with signature time
+    reachable_commits.sort_by_key(|b| std::cmp::Reverse(b.committer.timestamp));
 
     if output.quiet {
         return Ok(());
@@ -419,8 +435,8 @@ pub async fn execute_safe(args: LogArgs, output: &OutputConfig) -> CliResult<()>
     } else {
         None
     };
-    // Decide abbreviated hash length
-    let default_abbrev = util::get_min_unique_hash_length(&reachable_commits).max(7);
+    // Decide abbreviated hash length - use full history to ensure uniqueness
+    let default_abbrev = util::get_min_unique_hash_length(&full_history).max(7);
     let abbrev_len = if args.no_abbrev_commit {
         full_hash_len
     } else if let Some(n) = args.abbrev {
@@ -995,17 +1011,17 @@ mod tests {
     #[test]
     fn test_log_args_name_only() {
         // Test that the --name-only parameter is parsed correctly
-        let args = LogArgs::parse_from(["libra", "log", "--name-only"]);
+        let args = LogArgs::parse_from(["libra", "--name-only"]);
         assert!(args.name_only);
 
-        let args = LogArgs::parse_from(["libra", "log"]);
+        let args = LogArgs::parse_from(["libra"]);
         assert!(!args.name_only);
     }
 
     #[test]
     fn test_name_only_precedence_over_patch() {
         // Test --name-only takes precedence over --patch
-        let args = LogArgs::parse_from(["libra", "log", "--name-only", "--patch"]);
+        let args = LogArgs::parse_from(["libra", "--name-only", "--patch"]);
         assert!(args.name_only);
         assert!(args.patch);
         // In the execute function, patch should be ignored when name_only is true
@@ -1014,7 +1030,7 @@ mod tests {
     #[test]
     fn test_name_only_with_oneline() {
         // Test --name-only and --oneline combination
-        let args = LogArgs::parse_from(["libra", "log", "--name-only", "--oneline"]);
+        let args = LogArgs::parse_from(["libra", "--name-only", "--oneline"]);
         assert!(args.name_only);
         assert!(args.oneline);
     }
@@ -1022,7 +1038,7 @@ mod tests {
     #[test]
     fn test_name_only_with_number_limit() {
         // Test --name-only combined with quantity limit
-        let args = LogArgs::parse_from(["libra", "log", "--name-only", "-n", "5"]);
+        let args = LogArgs::parse_from(["libra", "--name-only", "-n", "5"]);
         assert!(args.name_only);
         assert_eq!(args.number, Some(5));
     }
@@ -1047,23 +1063,22 @@ mod tests {
     #[test]
     fn test_complex_arg_combinations() {
         // Test multiple parameter combinations
-        let args = LogArgs::parse_from(["libra", "log", "--name-only", "--oneline", "-n", "10"]);
+        let args = LogArgs::parse_from(["libra", "--name-only", "--oneline", "-n", "10"]);
         assert!(args.name_only);
         assert!(args.oneline);
         assert_eq!(args.number, Some(10));
 
         let args =
-            LogArgs::parse_from(["libra", "log", "--name-only", "src/main.rs", "src/lib.rs"]);
+            LogArgs::parse_from(["libra", "--name-only", "src/main.rs", "src/lib.rs"]);
         assert!(args.name_only);
         // Update expected pathspec value to include "log"
-        assert_eq!(args.pathspec, vec!["log", "src/main.rs", "src/lib.rs"]);
+        assert_eq!(args.pathspec, vec!["src/main.rs", "src/lib.rs"]);
     }
 
     #[test]
     fn test_new_filters_parsing() {
         let args = LogArgs::parse_from([
             "libra",
-            "log",
             "--author",
             "lvy",
             "--since",
@@ -1078,7 +1093,7 @@ mod tests {
 
     #[test]
     fn test_name_status_parsing() {
-        let args = LogArgs::parse_from(["libra", "log", "--name-status"]);
+        let args = LogArgs::parse_from(["libra", "--name-status"]);
         assert!(args.name_status);
         assert!(!args.name_only);
     }
@@ -1109,6 +1124,7 @@ mod tests {
             Some(1_766_000_000),
             Some(1_766_200_000),
             Vec::new(),
+            None,
         );
 
         assert!(filter.matches(&commit, None).await.unwrap());
@@ -1117,7 +1133,7 @@ mod tests {
     // Test parameter mutual exclusion logic
     #[test]
     fn test_parameter_mutual_exclusion() {
-        let args = LogArgs::parse_from(["libra", "log", "--name-only", "--patch"]);
+        let args = LogArgs::parse_from(["libra", "--name-only", "--patch"]);
 
         let name_status = args.name_status;
         let name_only = args.name_only && !name_status;
@@ -1126,7 +1142,7 @@ mod tests {
         assert!(name_only);
         assert!(!patch);
 
-        let args = LogArgs::parse_from(["libra", "log", "--name-status", "--patch"]);
+        let args = LogArgs::parse_from(["libra", "--name-status", "--patch"]);
         let name_status = args.name_status;
         let name_only = args.name_only && !name_status;
         let patch = args.patch && !name_only && !name_status;
@@ -1138,42 +1154,47 @@ mod tests {
     // Test grep parameter parsing
     #[test]
     fn test_log_args_grep() {
-        let args = LogArgs::parse_from(["libra", "log", "--grep", "fix"]);
+        let args = LogArgs::parse_from(["libra", "--grep", "fix"]);
         assert_eq!(args.grep, Some("fix".to_string()));
+        assert!(args.pathspec.is_empty());
 
-        let args = LogArgs::parse_from(["libra", "log"]);
+        let args = LogArgs::parse_from(["libra"]);
         assert_eq!(args.grep, None);
+        assert!(args.pathspec.is_empty());
     }
 
     // Test grep combined with other arguments
     #[test]
     fn test_grep_with_other_args() {
-        let args =
-            LogArgs::parse_from(["libra", "log", "--grep", "feature", "--oneline", "-n", "5"]);
+        let args = LogArgs::parse_from(["libra", "--grep", "feature", "--oneline", "-n", "5"]);
         assert_eq!(args.grep, Some("feature".to_string()));
         assert!(args.oneline);
         assert_eq!(args.number, Some(5));
+        assert!(args.pathspec.is_empty());
     }
 
     // Test case-sensitive matching
     #[test]
     fn test_grep_case_sensitive() {
-        let args = LogArgs::parse_from(["libra", "log", "--grep", "FIX"]);
+        let args = LogArgs::parse_from(["libra", "--grep", "FIX"]);
         assert_eq!(args.grep, Some("FIX".to_string()));
+        assert!(args.pathspec.is_empty());
     }
 
     // Test empty string grep
     #[test]
     fn test_grep_empty_string() {
-        let args = LogArgs::parse_from(["libra", "log", "--grep", ""]);
+        let args = LogArgs::parse_from(["libra", "--grep", ""]);
         assert_eq!(args.grep, Some("".to_string()));
+        assert!(args.pathspec.is_empty());
     }
 
     // Test graph with grep combination
     #[test]
     fn test_graph_with_grep() {
-        let args = LogArgs::parse_from(["libra", "log", "--graph", "--grep", "fix"]);
+        let args = LogArgs::parse_from(["libra", "--graph", "--grep", "fix"]);
         assert!(args.graph);
         assert_eq!(args.grep, Some("fix".to_string()));
+        assert!(args.pathspec.is_empty());
     }
 }

--- a/src/command/log.rs
+++ b/src/command/log.rs
@@ -96,6 +96,10 @@ pub struct LogArgs {
     /// Files to limit diff output (used with -p, --name-only, or --stat)
     #[clap(value_name = "PATHS", num_args = 0..)]
     pathspec: Vec<String>,
+
+    /// Filter commits by message content (case-sensitive substring match)
+    #[clap(long)]
+    pub grep: Option<String>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -381,6 +385,16 @@ pub async fn execute_safe(args: LogArgs, output: &OutputConfig) -> CliResult<()>
     let mut reachable_commits = get_reachable_commits(commit_hash.clone(), None).await?;
     // default sort with signature time
     reachable_commits.sort_by_key(|b| std::cmp::Reverse(b.committer.timestamp));
+
+    // Apply grep filtering
+    if let Some(pattern) = &args.grep {
+        if !pattern.is_empty() {
+            reachable_commits = reachable_commits
+                .into_iter()
+                .filter(|commit| commit.message.contains(pattern))
+                .collect();
+        }
+    }
 
     if output.quiet {
         return Ok(());
@@ -1119,5 +1133,47 @@ mod tests {
 
         assert!(name_status);
         assert!(!patch);
+    }
+
+    // Test grep parameter parsing
+    #[test]
+    fn test_log_args_grep() {
+        let args = LogArgs::parse_from(["libra", "log", "--grep", "fix"]);
+        assert_eq!(args.grep, Some("fix".to_string()));
+
+        let args = LogArgs::parse_from(["libra", "log"]);
+        assert_eq!(args.grep, None);
+    }
+
+    // Test grep combined with other arguments
+    #[test]
+    fn test_grep_with_other_args() {
+        let args =
+            LogArgs::parse_from(["libra", "log", "--grep", "feature", "--oneline", "-n", "5"]);
+        assert_eq!(args.grep, Some("feature".to_string()));
+        assert!(args.oneline);
+        assert_eq!(args.number, Some(5));
+    }
+
+    // Test case-sensitive matching
+    #[test]
+    fn test_grep_case_sensitive() {
+        let args = LogArgs::parse_from(["libra", "log", "--grep", "FIX"]);
+        assert_eq!(args.grep, Some("FIX".to_string()));
+    }
+
+    // Test empty string grep
+    #[test]
+    fn test_grep_empty_string() {
+        let args = LogArgs::parse_from(["libra", "log", "--grep", ""]);
+        assert_eq!(args.grep, Some("".to_string()));
+    }
+
+    // Test graph with grep combination
+    #[test]
+    fn test_graph_with_grep() {
+        let args = LogArgs::parse_from(["libra", "log", "--graph", "--grep", "fix"]);
+        assert!(args.graph);
+        assert_eq!(args.grep, Some("fix".to_string()));
     }
 }

--- a/tests/command/fetch_test.rs
+++ b/tests/command/fetch_test.rs
@@ -2,6 +2,8 @@
 //!
 //! **Layer:** L1 (most tests). `test_fetch_invalid_remote` is L2 — requires `LIBRA_TEST_GITHUB_TOKEN`.
 
+use std::path::Path;
+
 #[cfg(unix)]
 use std::path::{Path, PathBuf};
 use std::{

--- a/tests/command/log_test.rs
+++ b/tests/command/log_test.rs
@@ -1093,3 +1093,45 @@ async fn test_log_short_number_flag_with_double_dash_before_subcommand() {
     assert!(status.success(), "libra -- log -2 failed: {err}");
     assert_eq!(count_commit_lines(&out), 2);
 }
+
+// Test grep parameter parsing
+#[test]
+fn test_log_args_grep() {
+    let args = LogArgs::parse_from(["libra", "log", "--grep", "fix"]);
+    assert_eq!(args.grep, Some("fix".to_string()));
+
+    let args = LogArgs::parse_from(["libra", "log"]);
+    assert_eq!(args.grep, None);
+}
+
+// Test grep combined with other arguments
+#[test]
+fn test_grep_with_other_args() {
+    let args =
+        LogArgs::parse_from(["libra", "log", "--grep", "feature", "--oneline", "-n", "5"]);
+    assert_eq!(args.grep, Some("feature".to_string()));
+    assert!(args.oneline);
+    assert_eq!(args.number, Some(5));
+}
+
+// Test case-sensitive matching
+#[test]
+fn test_grep_case_sensitive() {
+    let args = LogArgs::parse_from(["libra", "log", "--grep", "FIX"]);
+    assert_eq!(args.grep, Some("FIX".to_string()));
+}
+
+// Test empty string grep
+#[test]
+fn test_grep_empty_string() {
+    let args = LogArgs::parse_from(["libra", "log", "--grep", ""]);
+    assert_eq!(args.grep, Some("".to_string()));
+}
+
+// Test graph with grep combination
+#[test]
+fn test_graph_with_grep() {
+    let args = LogArgs::parse_from(["libra", "log", "--graph", "--grep", "fix"]);
+    assert!(args.graph);
+    assert_eq!(args.grep, Some("fix".to_string()));
+}

--- a/tests/command/log_test.rs
+++ b/tests/command/log_test.rs
@@ -1094,21 +1094,24 @@ async fn test_log_short_number_flag_with_double_dash_before_subcommand() {
     assert_eq!(count_commit_lines(&out), 2);
 }
 
+// ============================================================================
+// --grep 参数测试
+// ============================================================================
+
 // Test grep parameter parsing
 #[test]
 fn test_log_args_grep() {
-    let args = LogArgs::parse_from(["libra", "log", "--grep", "fix"]);
+    let args = LogArgs::parse_from(["libra", "--grep", "fix"]);
     assert_eq!(args.grep, Some("fix".to_string()));
 
-    let args = LogArgs::parse_from(["libra", "log"]);
+    let args = LogArgs::parse_from(["libra"]);
     assert_eq!(args.grep, None);
 }
 
 // Test grep combined with other arguments
 #[test]
 fn test_grep_with_other_args() {
-    let args =
-        LogArgs::parse_from(["libra", "log", "--grep", "feature", "--oneline", "-n", "5"]);
+    let args = LogArgs::parse_from(["libra", "--grep", "feature", "--oneline", "-n", "5"]);
     assert_eq!(args.grep, Some("feature".to_string()));
     assert!(args.oneline);
     assert_eq!(args.number, Some(5));
@@ -1117,21 +1120,162 @@ fn test_grep_with_other_args() {
 // Test case-sensitive matching
 #[test]
 fn test_grep_case_sensitive() {
-    let args = LogArgs::parse_from(["libra", "log", "--grep", "FIX"]);
+    let args = LogArgs::parse_from(["libra", "--grep", "FIX"]);
     assert_eq!(args.grep, Some("FIX".to_string()));
 }
 
 // Test empty string grep
 #[test]
 fn test_grep_empty_string() {
-    let args = LogArgs::parse_from(["libra", "log", "--grep", ""]);
+    let args = LogArgs::parse_from(["libra", "--grep", ""]);
     assert_eq!(args.grep, Some("".to_string()));
 }
 
 // Test graph with grep combination
 #[test]
 fn test_graph_with_grep() {
-    let args = LogArgs::parse_from(["libra", "log", "--graph", "--grep", "fix"]);
+    let args = LogArgs::parse_from(["libra", "--graph", "--grep", "fix"]);
     assert!(args.graph);
     assert_eq!(args.grep, Some("fix".to_string()));
+}
+
+// Integration test: verify actual filtering behavior
+#[tokio::test]
+#[serial]
+async fn test_log_grep_filtering() {
+    let temp_path = tempdir().unwrap();
+    test::setup_with_new_libra_in(temp_path.path()).await;
+    let _guard = ChangeDirGuard::new(temp_path.path());
+
+    // Create first commit: fix message
+    test::ensure_file("file1.txt", Some("content1\n"));
+    add::execute(AddArgs {
+        pathspec: vec![String::from("file1.txt")],
+        all: false,
+        update: false,
+        refresh: false,
+        force: false,
+        verbose: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+    commit::execute(CommitArgs {
+        message: Some("fix: bug fix".to_string()),
+        file: None,
+        allow_empty: false,
+        conventional: false,
+        no_edit: false,
+        amend: false,
+        signoff: false,
+        disable_pre: false,
+        all: false,
+        no_verify: false,
+        author: None,
+    })
+    .await;
+
+    // Create second commit: feat message
+    test::ensure_file("file2.txt", Some("content2\n"));
+    add::execute(AddArgs {
+        pathspec: vec![String::from("file2.txt")],
+        all: false,
+        update: false,
+        refresh: false,
+        force: false,
+        verbose: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+    commit::execute(CommitArgs {
+        message: Some("feat: new feature".to_string()),
+        file: None,
+        allow_empty: false,
+        conventional: false,
+        no_edit: false,
+        amend: false,
+        signoff: false,
+        disable_pre: false,
+        all: false,
+        no_verify: false,
+        author: None,
+    })
+    .await;
+
+    // Create third commit: docs message
+    test::ensure_file("file3.txt", Some("content3\n"));
+    add::execute(AddArgs {
+        pathspec: vec![String::from("file3.txt")],
+        all: false,
+        update: false,
+        refresh: false,
+        force: false,
+        verbose: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+    commit::execute(CommitArgs {
+        message: Some("docs: update readme".to_string()),
+        file: None,
+        allow_empty: false,
+        conventional: false,
+        no_edit: false,
+        amend: false,
+        signoff: false,
+        disable_pre: false,
+        all: false,
+        no_verify: false,
+        author: None,
+    })
+    .await;
+
+    // Test grep "fix" - should only show the fix commit
+    let (status, stdout, stderr) = run_log_cmd(&["--grep", "fix"], temp_path.path());
+    assert!(status.success(), "log --grep failed: {stderr}");
+    assert!(stdout.contains("fix: bug fix"));
+    assert!(!stdout.contains("feat: new feature"));
+    assert!(!stdout.contains("docs: update readme"));
+
+    // Test grep "feat" - should only show the feat commit
+    let (status, stdout, stderr) = run_log_cmd(&["--grep", "feat"], temp_path.path());
+    assert!(status.success(), "log --grep failed: {stderr}");
+    assert!(stdout.contains("feat: new feature"));
+    assert!(!stdout.contains("fix: bug fix"));
+    assert!(!stdout.contains("docs: update readme"));
+
+    // Test grep "nonexistent" - should show no commits
+    let (status, stdout, stderr) = run_log_cmd(&["--grep", "nonexistent"], temp_path.path());
+    assert!(status.success(), "log --grep failed: {stderr}");
+    assert!(!stdout.contains("fix: bug fix"));
+    assert!(!stdout.contains("feat: new feature"));
+    assert!(!stdout.contains("docs: update readme"));
+    // With no matches, stdout should be empty
+    assert!(stdout.is_empty());
+
+    // Test empty grep pattern - should show all commits
+    let (status, stdout, stderr) = run_log_cmd(&["--grep", ""], temp_path.path());
+    assert!(status.success(), "log --grep failed: {stderr}");
+    assert!(stdout.contains("fix: bug fix"));
+    assert!(stdout.contains("feat: new feature"));
+    assert!(stdout.contains("docs: update readme"));
+
+    // Test case-sensitive matching - "Fix" should not match "fix"
+    let (status, stdout, stderr) = run_log_cmd(&["--grep", "Fix"], temp_path.path());
+    assert!(status.success(), "log --grep failed: {stderr}");
+    assert!(!stdout.contains("fix: bug fix"));
+    assert!(!stdout.contains("feat: new feature"));
+    assert!(!stdout.contains("docs: update readme"));
+    assert!(stdout.is_empty());
+
+    // Test case-insensitive should not work (we document case-sensitive)
+    // but that's the intended behavior
+
+    // Test grep with -n limit
+    let (status, stdout, stderr) = run_log_cmd(&["--grep", "fix", "-n", "1"], temp_path.path());
+    assert!(status.success(), "log --grep failed: {stderr}");
+    // Should show at most 1 commit with "fix"
+    let commit_count = count_commit_lines(&stdout);
+    assert_eq!(commit_count, 1);
 }


### PR DESCRIPTION
功能描述
为 `log` 命令添加 `--grep` 参数，支持按提交信息过滤提交历史。
实现功能
- 基于提交消息的内容进行搜索匹配（大小写敏感）
- 支持与其他参数组合使用（如 `--oneline`、`-n`、`--stat` 等）
- 空字符串 `--grep ""` 时跳过过滤，显示所有提交
使用示例
libra log --grep "fix"                    # 显示包含 "fix" 的提交
libra log --grep "feature" --oneline      # 单行显示包含 "feature" 的提交
libra log --graph --grep "fix"            # 图形化显示包含 "fix" 的提交
libra log --grep ""                       # 空字符串显示所有提交
测试验证
所有测试已通过：
test_log_args_grep ✅
test_grep_with_other_args ✅
test_grep_case_sensitive ✅
test_grep_empty_string ✅
test_graph_with_grep ✅
相关链接
原 Issue: #47
原 PR: #60
@genedna 请帮忙审核