### PR TITLE
fix(config): stabilize working dir and temp dir resolution

### DIFF
--- a/src/command/cloud.rs
+++ b/src/command/cloud.rs
@@ -8,6 +8,7 @@
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
+    path::PathBuf,
     sync::Arc,
 };
 
@@ -591,14 +592,31 @@ async fn execute_status(args: StatusArgs) -> Result<(), String> {
     Ok(())
 }
 
-async fn resolve_cloud_env(name: &str) -> Result<Option<String>, String> {
-    crate::internal::config::resolve_env(name)
+fn cloud_local_db_path() -> Result<PathBuf, String> {
+    let storage = util::try_get_storage_path(None)
+        .map_err(|e| format!("failed to resolve current repository storage: {e}"))?;
+    Ok(storage.join(util::DATABASE))
+}
+
+async fn resolve_cloud_env(
+    name: &str,
+    local_db_path: Option<&std::path::Path>,
+) -> Result<Option<String>, String> {
+    let local_target = match local_db_path {
+        Some(db_path) => crate::internal::config::LocalIdentityTarget::ExplicitDb(db_path),
+        None => crate::internal::config::LocalIdentityTarget::CurrentRepo,
+    };
+
+    crate::internal::config::resolve_env_for_target(name, local_target)
         .await
         .map_err(|e| format!("failed to resolve '{name}' from env or config: {e}"))
 }
 
-async fn resolve_required_cloud_env(name: &str) -> Result<String, String> {
-    match resolve_cloud_env(name).await? {
+async fn resolve_required_cloud_env(
+    name: &str,
+    local_db_path: Option<&std::path::Path>,
+) -> Result<String, String> {
+    match resolve_cloud_env(name, local_db_path).await? {
         Some(value) if !value.is_empty() => Ok(value),
         _ => Err(format!("{name} not set")),
     }
@@ -606,11 +624,22 @@ async fn resolve_required_cloud_env(name: &str) -> Result<String, String> {
 
 /// Create R2 remote storage from environment variables and config.
 async fn create_r2_storage(repo_id: &str) -> Result<RemoteStorage, String> {
-    let endpoint = resolve_required_cloud_env("LIBRA_STORAGE_ENDPOINT").await?;
-    let bucket = resolve_required_cloud_env("LIBRA_STORAGE_BUCKET").await?;
-    let access_key = resolve_required_cloud_env("LIBRA_STORAGE_ACCESS_KEY").await?;
-    let secret_key = resolve_required_cloud_env("LIBRA_STORAGE_SECRET_KEY").await?;
-    let region = resolve_cloud_env("LIBRA_STORAGE_REGION")
+    let local_db_path = cloud_local_db_path()?;
+    create_r2_storage_for_db_path(repo_id, &local_db_path).await
+}
+
+async fn create_r2_storage_for_db_path(
+    repo_id: &str,
+    local_db_path: &std::path::Path,
+) -> Result<RemoteStorage, String> {
+    let endpoint =
+        resolve_required_cloud_env("LIBRA_STORAGE_ENDPOINT", Some(local_db_path)).await?;
+    let bucket = resolve_required_cloud_env("LIBRA_STORAGE_BUCKET", Some(local_db_path)).await?;
+    let access_key =
+        resolve_required_cloud_env("LIBRA_STORAGE_ACCESS_KEY", Some(local_db_path)).await?;
+    let secret_key =
+        resolve_required_cloud_env("LIBRA_STORAGE_SECRET_KEY", Some(local_db_path)).await?;
+    let region = resolve_cloud_env("LIBRA_STORAGE_REGION", Some(local_db_path))
         .await?
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| "auto".to_string());
@@ -647,9 +676,10 @@ async fn validate_cloud_backup_env(skip_r2: bool) -> Result<(), String> {
         ]);
     }
 
+    let local_db_path = cloud_local_db_path()?;
     let mut missing = Vec::new();
     for key in required {
-        match resolve_cloud_env(key).await? {
+        match resolve_cloud_env(key, Some(&local_db_path)).await? {
             Some(value) if !value.is_empty() => {}
             _ => missing.push(key),
         }
@@ -888,30 +918,76 @@ mod tests {
         let _secret = ClearedEnvVarGuard::new("LIBRA_STORAGE_SECRET_KEY");
         let _region = ClearedEnvVarGuard::new("LIBRA_STORAGE_REGION");
 
+        let repo_db_path = repo.path().join(".libra").join(util::DATABASE);
+
+        rt.block_on(crate::internal::vault::lazy_init_vault_for_scope("local"))
+            .unwrap();
+
+        let encrypted_endpoint = rt
+            .block_on(crate::internal::config::encrypt_value(
+                "https://storage.example.com",
+                "local",
+            ))
+            .unwrap();
+        let encrypted_bucket = rt
+            .block_on(crate::internal::config::encrypt_value(
+                "test-bucket",
+                "local",
+            ))
+            .unwrap();
+        let encrypted_access = rt
+            .block_on(crate::internal::config::encrypt_value(
+                "test-access",
+                "local",
+            ))
+            .unwrap();
+        let encrypted_secret = rt
+            .block_on(crate::internal::config::encrypt_value(
+                "test-secret",
+                "local",
+            ))
+            .unwrap();
+        let encrypted_region = rt
+            .block_on(crate::internal::config::encrypt_value("auto", "local"))
+            .unwrap();
+
         rt.block_on(async {
             ConfigKv::set(
                 "vault.env.LIBRA_STORAGE_ENDPOINT",
-                "https://storage.example.com",
-                false,
+                &encrypted_endpoint,
+                true,
             )
             .await
             .unwrap();
-            ConfigKv::set("vault.env.LIBRA_STORAGE_BUCKET", "test-bucket", false)
+            ConfigKv::set("vault.env.LIBRA_STORAGE_BUCKET", &encrypted_bucket, true)
                 .await
                 .unwrap();
-            ConfigKv::set("vault.env.LIBRA_STORAGE_ACCESS_KEY", "test-access", false)
-                .await
-                .unwrap();
-            ConfigKv::set("vault.env.LIBRA_STORAGE_SECRET_KEY", "test-secret", false)
-                .await
-                .unwrap();
-            ConfigKv::set("vault.env.LIBRA_STORAGE_REGION", "auto", false)
+            ConfigKv::set(
+                "vault.env.LIBRA_STORAGE_ACCESS_KEY",
+                &encrypted_access,
+                true,
+            )
+            .await
+            .unwrap();
+            ConfigKv::set(
+                "vault.env.LIBRA_STORAGE_SECRET_KEY",
+                &encrypted_secret,
+                true,
+            )
+            .await
+            .unwrap();
+            ConfigKv::set("vault.env.LIBRA_STORAGE_REGION", &encrypted_region, true)
                 .await
                 .unwrap();
         });
 
-        rt.block_on(create_r2_storage("repo-from-config"))
-            .expect("R2 storage should initialize from local config values");
+        let _manifest_dir = ChangeDirGuard::new(env!("CARGO_MANIFEST_DIR"));
+
+        rt.block_on(create_r2_storage_for_db_path(
+            "repo-from-config",
+            &repo_db_path,
+        ))
+        .expect("R2 storage should initialize from local config values even after cwd drift");
     }
 
     #[test]
@@ -934,7 +1010,8 @@ mod tests {
             .block_on(validate_cloud_backup_env(true))
             .expect_err("global config resolution failure should surface");
         assert!(
-            err.contains("failed to connect to global config"),
+            err.contains("failed to open config database")
+                || err.contains("failed to connect to global config"),
             "unexpected error: {err}"
         );
     }

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -279,7 +279,12 @@ fn load_vault_unseal_key_sync() -> Result<Option<Vec<u8>>, String> {
 }
 
 fn resolve_home_directory() -> Result<PathBuf, String> {
-    for key in ["HOME", "USERPROFILE"] {
+    #[cfg(windows)]
+    let env_keys = ["USERPROFILE", "HOME"];
+    #[cfg(not(windows))]
+    let env_keys = ["HOME", "USERPROFILE"];
+
+    for key in env_keys {
         if let Some(value) = std::env::var_os(key)
             && !value.is_empty()
         {

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -278,8 +278,20 @@ fn load_vault_unseal_key_sync() -> Result<Option<Vec<u8>>, String> {
     }
 }
 
+fn resolve_home_directory() -> Result<PathBuf, String> {
+    for key in ["HOME", "USERPROFILE"] {
+        if let Some(value) = std::env::var_os(key)
+            && !value.is_empty()
+        {
+            return Ok(PathBuf::from(value));
+        }
+    }
+
+    dirs::home_dir().ok_or_else(|| "cannot determine home directory".to_string())
+}
+
 fn ensure_vault_ssh_tmp_dir() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or_else(|| "cannot determine home directory".to_string())?;
+    let home = resolve_home_directory()?;
     let tmp_dir = home.join(".libra").join("tmp");
     std::fs::create_dir_all(&tmp_dir).map_err(|e| {
         format!(

--- a/src/internal/config.rs
+++ b/src/internal/config.rs
@@ -647,9 +647,31 @@ pub async fn decrypt_value(hex_ciphertext: &str, scope: &str) -> Result<String> 
     let unseal_key = crate::internal::vault::load_unseal_key_for_scope(scope)
         .await
         .ok_or_else(|| anyhow!("vault not initialized for {scope} scope — cannot decrypt value"))?;
+    decrypt_value_with_unseal_key(hex_ciphertext, &unseal_key)
+}
+
+async fn decrypt_value_for_local_target(
+    hex_ciphertext: &str,
+    local_target: LocalIdentityTarget<'_>,
+) -> Result<String> {
+    let unseal_key = match local_target {
+        LocalIdentityTarget::CurrentRepo => {
+            crate::internal::vault::load_unseal_key_for_scope("local").await
+        }
+        LocalIdentityTarget::ExplicitDb(db_path) => {
+            crate::internal::vault::load_unseal_key_for_db_path(db_path).await
+        }
+        LocalIdentityTarget::None => None,
+    }
+    .ok_or_else(|| anyhow!("vault not initialized for local scope — cannot decrypt value"))?;
+
+    decrypt_value_with_unseal_key(hex_ciphertext, &unseal_key)
+}
+
+fn decrypt_value_with_unseal_key(hex_ciphertext: &str, unseal_key: &[u8]) -> Result<String> {
     let ciphertext =
         hex::decode(hex_ciphertext).context("failed to decode encrypted config value hex")?;
-    crate::internal::vault::decrypt_token(&unseal_key, &ciphertext)
+    crate::internal::vault::decrypt_token(unseal_key, &ciphertext)
 }
 
 /// Encrypt a value using the vault unseal key for the given scope.
@@ -670,63 +692,33 @@ pub async fn encrypt_value(value: &str, scope: &str) -> Result<String> {
 /// `name` is the raw env var name (e.g. `"GEMINI_API_KEY"`).
 /// Returns `Err` if a vault/DB query fails (not the same as "not configured").
 pub async fn resolve_env(name: &str) -> Result<Option<String>> {
+    resolve_env_for_target(name, LocalIdentityTarget::CurrentRepo).await
+}
+
+/// Resolve an environment variable using an explicit local config target.
+///
+/// Resolution order remains:
+/// 1. System environment variable (`std::env::var`)
+/// 2. Local config for `local_target` (`vault.env.<name>`)
+/// 3. Global config (`vault.env.<name>` in `~/.libra/config.db`)
+pub async fn resolve_env_for_target(
+    name: &str,
+    local_target: LocalIdentityTarget<'_>,
+) -> Result<Option<String>> {
     // 1. System environment variable — per-process override (12-Factor)
     if let Ok(val) = std::env::var(name) {
         return Ok(Some(val));
     }
 
-    // 2. Local config (vault.env.*)
     let vault_key = format!("vault.env.{name}");
-    match ConfigKv::get(&vault_key).await {
-        Ok(Some(entry)) => {
-            if entry.encrypted {
-                // Decrypt the stored value using local-scope unseal key
-                let plaintext = decrypt_value(&entry.value, "local")
-                    .await
-                    .context(format!("failed to decrypt vault.env.{name}"))?;
-                return Ok(Some(plaintext));
-            }
-            return Ok(Some(entry.value));
-        }
-        Ok(None) => {}
-        Err(e) => {
-            return Err(e.context(format!("failed to read '{name}' from local config")));
-        }
+
+    // 2. Local config (vault.env.*)
+    if let Some(value) = local_env_value_for_target(local_target, &vault_key).await? {
+        return Ok(Some(value));
     }
 
     // 3. Global config — lowest priority
-    if let Some(global_path) = global_config_path()
-        && global_path.exists()
-    {
-        let conn = crate::internal::db::establish_connection(&global_path.to_string_lossy())
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to connect to global config '{}'",
-                    global_path.display()
-                )
-            })?;
-        match ConfigKv::get_with_conn(&conn, &vault_key).await {
-            Ok(Some(entry)) => {
-                if entry.encrypted {
-                    let plaintext =
-                        decrypt_value(&entry.value, "global")
-                            .await
-                            .context(format!(
-                                "failed to decrypt vault.env.{name} from global config"
-                            ))?;
-                    return Ok(Some(plaintext));
-                }
-                return Ok(Some(entry.value));
-            }
-            Ok(None) => {}
-            Err(e) => {
-                return Err(e.context(format!("failed to read '{name}' from global config")));
-            }
-        }
-    }
-
-    Ok(None)
+    global_env_value(name, &vault_key).await
 }
 
 /// Resolve the global config database path.
@@ -807,6 +799,66 @@ pub async fn resolve_user_identity_sources(
     })
 }
 
+async fn local_env_value_for_target(
+    local_target: LocalIdentityTarget<'_>,
+    vault_key: &str,
+) -> Result<Option<String>> {
+    let Some(entry) = local_config_entry_for_target(local_target, vault_key).await? else {
+        return Ok(None);
+    };
+
+    if entry.encrypted {
+        let plaintext = decrypt_value_for_local_target(&entry.value, local_target)
+            .await
+            .context(format!("failed to decrypt {vault_key}"))?;
+        return Ok(Some(plaintext));
+    }
+
+    Ok(Some(entry.value))
+}
+
+async fn local_config_entry_for_target(
+    local_target: LocalIdentityTarget<'_>,
+    key: &str,
+) -> Result<Option<ConfigKvEntry>> {
+    match local_target {
+        LocalIdentityTarget::CurrentRepo => {
+            let storage = crate::utils::util::try_get_storage_path(None)
+                .context("failed to resolve current repository storage")?;
+            let db_path = storage.join(crate::utils::util::DATABASE);
+            read_config_entry_from_db_path(&db_path, key).await
+        }
+        LocalIdentityTarget::ExplicitDb(db_path) => {
+            read_config_entry_from_db_path(db_path, key).await
+        }
+        LocalIdentityTarget::None => Ok(None),
+    }
+}
+
+async fn global_env_value(name: &str, vault_key: &str) -> Result<Option<String>> {
+    let Some(global_path) = global_config_path() else {
+        return Ok(None);
+    };
+    if !global_path.exists() {
+        return Ok(None);
+    }
+
+    let Some(entry) = read_config_entry_from_db_path(&global_path, vault_key).await? else {
+        return Ok(None);
+    };
+
+    if entry.encrypted {
+        let plaintext = decrypt_value(&entry.value, "global")
+            .await
+            .context(format!(
+                "failed to decrypt vault.env.{name} from global config"
+            ))?;
+        return Ok(Some(plaintext));
+    }
+
+    Ok(Some(entry.value))
+}
+
 async fn local_config_value_for_target(
     local_target: LocalIdentityTarget<'_>,
     key: &str,
@@ -836,6 +888,17 @@ async fn global_config_value(key: &str) -> Result<Option<String>> {
 }
 
 async fn read_config_value_from_db_path(db_path: &Path, key: &str) -> Result<Option<String>> {
+    let entry = read_config_entry_from_db_path(db_path, key).await?;
+    Ok(entry.and_then(|entry| {
+        let trimmed = entry.value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    }))
+}
+
+async fn read_config_entry_from_db_path(
+    db_path: &Path,
+    key: &str,
+) -> Result<Option<ConfigKvEntry>> {
     if !db_path.exists() {
         return Ok(None);
     }
@@ -843,17 +906,12 @@ async fn read_config_value_from_db_path(db_path: &Path, key: &str) -> Result<Opt
     let conn = get_db_conn_instance_for_path(db_path)
         .await
         .with_context(|| format!("failed to open config database '{}'", db_path.display()))?;
-    let entry = ConfigKv::get_with_conn(&conn, key).await.with_context(|| {
+    ConfigKv::get_with_conn(&conn, key).await.with_context(|| {
         format!(
             "failed to query '{key}' from config database '{}'",
             db_path.display()
         )
-    })?;
-
-    Ok(entry.and_then(|entry| {
-        let trimmed = entry.value.trim();
-        (!trimmed.is_empty()).then(|| trimmed.to_string())
-    }))
+    })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/internal/vault.rs
+++ b/src/internal/vault.rs
@@ -603,6 +603,25 @@ pub async fn load_unseal_key_for_scope(scope: &str) -> Option<Vec<u8>> {
     }
 }
 
+/// Load the local unseal key for the repository backed by `db_path`.
+///
+/// This is used when callers need to resolve local secrets for an explicit
+/// repository target instead of the current working directory repository.
+pub async fn load_unseal_key_for_db_path(db_path: &Path) -> Option<Vec<u8>> {
+    if let Ok(repo_id) = repo_id_for_db_path(db_path).await
+        && let Some(hex_key) = load_unseal_key_from_home_for_repo_id(&repo_id).await
+    {
+        return hex::decode(hex_key).ok();
+    }
+
+    use crate::internal::{config::ConfigKv, db::get_db_conn_instance_for_path};
+    let conn = get_db_conn_instance_for_path(db_path).await.ok()?;
+    let entry = ConfigKv::get_with_conn(&conn, "vault.unsealkey")
+        .await
+        .ok()??;
+    hex::decode(entry.value).ok()
+}
+
 /// Load global unseal key from `~/.libra/vault-unseal-key`.
 async fn load_global_unseal_key() -> Option<Vec<u8>> {
     let home = dirs::home_dir()?;
@@ -879,19 +898,47 @@ async fn recover_root_token(unseal_key: &[u8]) -> Result<String> {
 
 /// Resolve the path `~/.libra/vault-keys/<repo-id>` for the current repo.
 async fn unseal_key_path() -> Result<std::path::PathBuf> {
+    let repo_id = current_repo_id().await?;
+    unseal_key_path_for_repo_id(&repo_id)
+}
+
+async fn current_repo_id() -> Result<String> {
     use crate::internal::config::ConfigKv;
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("cannot determine home directory"))?;
-    let repo_id = ConfigKv::get("libra.repoid")
+    ConfigKv::get("libra.repoid")
         .await?
         .map(|e| e.value)
-        .ok_or_else(|| anyhow!("libra.repoid not set — was the repo initialized?"))?;
+        .ok_or_else(|| anyhow!("libra.repoid not set — was the repo initialized?"))
+}
+
+async fn repo_id_for_db_path(db_path: &Path) -> Result<String> {
+    use crate::internal::{config::ConfigKv, db::get_db_conn_instance_for_path};
+    let conn = get_db_conn_instance_for_path(db_path)
+        .await
+        .context("failed to open repository config database")?;
+    ConfigKv::get_with_conn(&conn, "libra.repoid")
+        .await?
+        .map(|e| e.value)
+        .ok_or_else(|| anyhow!("libra.repoid not set — was the repo initialized?"))
+}
+
+fn unseal_key_path_for_repo_id(repo_id: &str) -> Result<std::path::PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("cannot determine home directory"))?;
     Ok(home.join(".libra").join("vault-keys").join(repo_id))
 }
 
 /// Read the hex-encoded unseal key from `~/.libra/vault-keys/<repo-id>`.
 async fn load_unseal_key_from_home() -> Option<String> {
     let path = unseal_key_path().await.ok()?;
-    tokio::fs::read_to_string(&path)
+    load_unseal_key_from_home_for_repo_id_path(&path).await
+}
+
+async fn load_unseal_key_from_home_for_repo_id(repo_id: &str) -> Option<String> {
+    let path = unseal_key_path_for_repo_id(repo_id).ok()?;
+    load_unseal_key_from_home_for_repo_id_path(&path).await
+}
+
+async fn load_unseal_key_from_home_for_repo_id_path(path: &Path) -> Option<String> {
+    tokio::fs::read_to_string(path)
         .await
         .ok()
         .map(|s| s.trim().to_string())
@@ -942,4 +989,35 @@ async fn remove_unseal_key_from_home() -> Result<()> {
             .context("failed to remove unseal key file")?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::load_unseal_key_for_db_path;
+    use crate::internal::{
+        config::ConfigKv,
+        db::{create_database, reset_db_conn_instance_for_path},
+    };
+
+    #[tokio::test]
+    async fn load_unseal_key_for_db_path_falls_back_to_legacy_db_key_without_repo_id() {
+        let temp = tempdir().expect("failed to create temp dir");
+        let db_path = temp.path().join("libra.db");
+        let expected = vec![0x12, 0x34, 0x56, 0x78];
+
+        let conn = create_database(db_path.to_string_lossy().as_ref())
+            .await
+            .expect("failed to create test database");
+        ConfigKv::set_with_conn(&conn, "vault.unsealkey", &hex::encode(&expected), false)
+            .await
+            .expect("failed to seed legacy vault.unsealkey");
+        drop(conn);
+
+        let actual = load_unseal_key_for_db_path(&db_path).await;
+        assert_eq!(actual, Some(expected));
+
+        reset_db_conn_instance_for_path(&db_path).await;
+    }
 }

--- a/src/utils/d1_client.rs
+++ b/src/utils/d1_client.rs
@@ -595,7 +595,8 @@ mod tests {
         };
         assert_eq!(err.code, 1101);
         assert!(
-            err.message.contains("failed to connect to global config"),
+            err.message.contains("failed to open config database")
+                || err.message.contains("failed to connect to global config"),
             "unexpected error: {}",
             err.message
         );


### PR DESCRIPTION
## Summary
- make explicit-db config resolution independent from the current working directory
- harden temp dir and vault path handling used by cloud/fetch flows
- keep the extraction limited to the working-dir/tmp-dir fixes requested in review

## Test plan
- Not rerun after split; this branch is an extraction of previously reviewed fixes from PR #345/#347

🤖 Generated with [Claude Code](https://claude.com/claude-code)