### PR TITLE
feat(clean): add -d, -x, -X, --exclude flags

### DIFF
--- a/src/command/clean.rs
+++ b/src/command/clean.rs
@@ -1,6 +1,9 @@
 //! Implements `clean` to remove untracked files from the working tree.
 
-use std::fs;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use clap::Parser;
 use git_internal::internal::index::Index;
@@ -8,6 +11,7 @@ use serde::Serialize;
 
 use crate::utils::{
     error::{CliError, CliResult, StableErrorCode},
+    ignore::{self, IgnorePolicy},
     output::{OutputConfig, emit_json_data},
     path, util, worktree,
 };
@@ -16,6 +20,10 @@ const CLEAN_EXAMPLES: &str = "\
 EXAMPLES:
   libra clean -n
   libra clean -f
+  libra clean -fd
+  libra clean -fx
+  libra clean -fX
+  libra clean -f --exclude '*.log'
   libra clean -n --json
 ";
 
@@ -28,6 +36,18 @@ pub struct CleanArgs {
     /// Force removal of untracked files
     #[clap(short, long)]
     pub force: bool,
+    /// Remove untracked directories in addition to untracked files
+    #[clap(short = 'd', long = "dir")]
+    pub directories: bool,
+    /// Remove all untracked files, including those in .gitignore/.libraignore
+    #[clap(short = 'x')]
+    pub ignored: bool,
+    /// Remove only untracked files that are in .gitignore/.libraignore
+    #[clap(short = 'X')]
+    pub only_ignored: bool,
+    /// Exclude files matching the given pattern (can be repeated)
+    #[clap(long = "exclude", value_name = "pattern")]
+    pub exclude: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -40,6 +60,8 @@ struct CleanOutput {
 enum CleanError {
     #[error("clean requires -f or -n (use -f to remove files, -n to dry-run)")]
     MissingMode,
+    #[error("invalid arguments: {0}")]
+    InvalidArgs(String),
     #[error("failed to load index: {0}")]
     LoadIndex(String),
     #[error("{0}")]
@@ -96,6 +118,13 @@ fn run_clean(args: CleanArgs) -> Result<CleanOutput, CleanError> {
         return Err(CleanError::MissingMode);
     }
 
+    // Validate mutually exclusive flags
+    if args.ignored && args.only_ignored {
+        return Err(CleanError::InvalidArgs(
+            "cannot use -x and -X together".to_string(),
+        ));
+    }
+
     let index_path = path::index();
     let index = match Index::load(&index_path) {
         Ok(index) => index,
@@ -107,8 +136,60 @@ fn run_clean(args: CleanArgs) -> Result<CleanOutput, CleanError> {
             }
         }
     };
-    let untracked = worktree::untracked_workdir_paths(&index)
-        .map_err(|e| CleanError::ScanUntracked(e.to_string()))?;
+
+    // Determine the ignore policy based on flags
+    let policy = if args.only_ignored {
+        IgnorePolicy::OnlyIgnored
+    } else if args.ignored {
+        IgnorePolicy::IncludeIgnored
+    } else {
+        IgnorePolicy::Respect
+    };
+
+    // Collect all workdir files and apply ignore policy
+    let workdir_files =
+        util::list_workdir_files().map_err(|e| CleanError::ScanUntracked(e.to_string()))?;
+    let filtered_files = ignore::filter_workdir_paths(workdir_files, policy, &index);
+
+    // Find untracked files
+    let mut untracked: Vec<PathBuf> = Vec::new();
+    for path in filtered_files {
+        let path_str = path.to_str().ok_or_else(|| {
+            CleanError::ScanUntracked(format!("path {:?} is not valid UTF-8", path))
+        })?;
+        if !worktree::index_has_any_stage(&index, path_str) {
+            untracked.push(path);
+        }
+    }
+
+    // If -d, also find untracked directories
+    if args.directories {
+        let untracked_dirs = find_untracked_dirs(&index, policy)?;
+        for dir in untracked_dirs {
+            // Skip the root directory (empty path)
+            if dir.as_os_str().is_empty() {
+                continue;
+            }
+            // Remove any files that are inside this directory from the untracked list
+            // since the directory itself will be removed
+            untracked.retain(|p| !p.starts_with(&dir));
+            // Add the directory if it's not already covered by a parent directory
+            if !untracked.iter().any(|p| dir.starts_with(p)) {
+                untracked.push(dir);
+            }
+        }
+    }
+
+    // Apply --exclude patterns
+    if !args.exclude.is_empty() {
+        untracked.retain(|path| {
+            let path_str = path.display().to_string();
+            !args
+                .exclude
+                .iter()
+                .any(|pattern| matches_exclude_pattern(&path_str, pattern))
+        });
+    }
 
     if untracked.is_empty() {
         return Ok(CleanOutput {
@@ -140,10 +221,17 @@ fn run_clean(args: CleanArgs) -> Result<CleanOutput, CleanError> {
             if !resolved.starts_with(&workdir) {
                 return Err(CleanError::OutsideWorkdir(abs_path.display().to_string()));
             }
-            fs::remove_file(&abs_path).map_err(|e| CleanError::RemoveFile {
-                path: abs_path.display().to_string(),
-                detail: e.to_string(),
-            })?;
+            if abs_path.is_dir() {
+                fs::remove_dir_all(&abs_path).map_err(|e| CleanError::RemoveFile {
+                    path: abs_path.display().to_string(),
+                    detail: e.to_string(),
+                })?;
+            } else {
+                fs::remove_file(&abs_path).map_err(|e| CleanError::RemoveFile {
+                    path: abs_path.display().to_string(),
+                    detail: e.to_string(),
+                })?;
+            }
             removed.push(path.display().to_string());
         }
     }
@@ -153,12 +241,115 @@ fn run_clean(args: CleanArgs) -> Result<CleanOutput, CleanError> {
     })
 }
 
+/// Find untracked directories based on the ignore policy.
+/// A directory is considered untracked if it does not contain any tracked files.
+fn find_untracked_dirs(index: &Index, policy: IgnorePolicy) -> Result<Vec<PathBuf>, CleanError> {
+    let workdir = util::working_dir();
+    let mut untracked_dirs = Vec::new();
+
+    fn scan_dir(
+        dir: &Path,
+        workdir: &Path,
+        index: &Index,
+        policy: IgnorePolicy,
+        untracked_dirs: &mut Vec<PathBuf>,
+    ) -> Result<(), CleanError> {
+        let entries = fs::read_dir(dir).map_err(|e| CleanError::ScanUntracked(e.to_string()))?;
+        let mut has_tracked = false;
+        let mut subdirs = Vec::new();
+
+        for entry in entries {
+            let entry = entry.map_err(|e| CleanError::ScanUntracked(e.to_string()))?;
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(workdir)
+                .map_err(|e| CleanError::ScanUntracked(e.to_string()))?;
+
+            if path.is_dir() {
+                let name = path.file_name().unwrap_or_default();
+                if name == ".git" || name == util::ROOT_DIR {
+                    continue;
+                }
+                subdirs.push(path.clone());
+            } else if let Some(path_str) = relative.to_str() {
+                // Check if this file is tracked
+                if index.tracked(path_str, 0) {
+                    has_tracked = true;
+                }
+            }
+        }
+
+        if !has_tracked {
+            // Check if this directory should be ignored
+            let relative = dir
+                .strip_prefix(workdir)
+                .map_err(|e| CleanError::ScanUntracked(e.to_string()))?;
+            let should_include = match policy {
+                IgnorePolicy::Respect => {
+                    // Only include if not ignored
+                    !ignore::should_ignore(relative, policy, index)
+                }
+                IgnorePolicy::IncludeIgnored => true,
+                IgnorePolicy::OnlyIgnored => {
+                    // Only include if ignored
+                    ignore::should_ignore(relative, IgnorePolicy::Respect, index)
+                }
+            };
+            if should_include {
+                untracked_dirs.push(relative.to_path_buf());
+            }
+        }
+
+        // Recurse into subdirs
+        for subdir in subdirs {
+            scan_dir(&subdir, workdir, index, policy, untracked_dirs)?;
+        }
+
+        Ok(())
+    }
+
+    scan_dir(&workdir, &workdir, index, policy, &mut untracked_dirs)?;
+    Ok(untracked_dirs)
+}
+
+/// Check if a path matches an exclude pattern using glob-style matching.
+/// Supports * (match any characters) and ? (match single character).
+fn matches_exclude_pattern(path: &str, pattern: &str) -> bool {
+    // Escape special regex characters, then convert glob patterns
+    let mut regex_pattern = String::new();
+    regex_pattern.push('^');
+    let chars = pattern.chars();
+    for c in chars {
+        match c {
+            '*' => regex_pattern.push_str(".*"),
+            '?' => regex_pattern.push('.'),
+            '.' | '+' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '^' | '$' | '\\' => {
+                regex_pattern.push('\\');
+                regex_pattern.push(c);
+            }
+            _ => regex_pattern.push(c),
+        }
+    }
+    regex_pattern.push('$');
+
+    if let Ok(re) = regex::Regex::new(&regex_pattern) {
+        re.is_match(path)
+    } else {
+        // Fallback to simple string matching
+        path.contains(pattern)
+    }
+}
+
 fn clean_cli_error(error: CleanError) -> CliError {
     match error {
         CleanError::MissingMode => CliError::fatal(error.to_string())
             .with_stable_code(StableErrorCode::CliInvalidArguments)
             .with_hint("use 'libra clean -n' to preview removals.")
             .with_hint("use 'libra clean -f' to remove untracked files."),
+        CleanError::InvalidArgs(message) => {
+            CliError::fatal(format!("invalid arguments: {message}"))
+                .with_stable_code(StableErrorCode::CliInvalidArguments)
+        }
         CleanError::LoadIndex(message) => {
             CliError::fatal(format!("failed to load index: {message}"))
                 .with_stable_code(StableErrorCode::IoReadFailed)

--- a/tests/command/clean_test.rs
+++ b/tests/command/clean_test.rs
@@ -26,6 +26,10 @@ async fn test_clean_dry_run_keeps_files() {
     clean::execute(CleanArgs {
         dry_run: true,
         force: false,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
     })
     .await;
 
@@ -46,6 +50,10 @@ async fn test_clean_force_removes_files() {
     clean::execute(CleanArgs {
         dry_run: false,
         force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
     })
     .await;
 
@@ -104,6 +112,10 @@ async fn test_clean_force_keeps_tracked_files() {
     clean::execute(CleanArgs {
         dry_run: false,
         force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
     })
     .await;
 
@@ -125,6 +137,10 @@ async fn test_clean_force_removes_nested_untracked() {
     clean::execute(CleanArgs {
         dry_run: false,
         force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
     })
     .await;
 
@@ -159,6 +175,10 @@ async fn test_clean_force_respects_ignore_rules() {
     clean::execute(CleanArgs {
         dry_run: false,
         force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
     })
     .await;
 
@@ -194,6 +214,10 @@ async fn test_clean_force_multiple_untracked_with_tracked() {
     clean::execute(CleanArgs {
         dry_run: false,
         force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
     })
     .await;
 
@@ -220,6 +244,10 @@ async fn test_clean_force_with_missing_index() {
     clean::execute(CleanArgs {
         dry_run: false,
         force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
     })
     .await;
 
@@ -335,6 +363,10 @@ async fn test_clean_force_with_long_path() {
     clean::execute(CleanArgs {
         dry_run: false,
         force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
     })
     .await;
 
@@ -359,6 +391,10 @@ async fn test_clean_force_does_not_follow_symlink_dirs() {
     clean::execute(CleanArgs {
         dry_run: false,
         force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
     })
     .await;
 
@@ -420,4 +456,291 @@ async fn test_clean_json_dry_run_lists_candidates() {
         .expect("removed should be an array");
     assert!(removed.iter().any(|path| path == "alpha.txt"));
     assert!(removed.iter().any(|path| path == "beta.txt"));
+}
+
+#[tokio::test]
+#[serial]
+/// Tests -d flag removes untracked directories.
+async fn test_clean_d_flag_removes_untracked_dirs() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    // Create an untracked directory with files
+    fs::create_dir_all("untracked_dir/sub").unwrap();
+    fs::write("untracked_dir/file.txt", "content").unwrap();
+    fs::write("untracked_dir/sub/nested.txt", "nested").unwrap();
+
+    clean::execute(CleanArgs {
+        dry_run: false,
+        force: true,
+        directories: true,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
+    })
+    .await;
+
+    assert!(!std::path::Path::new("untracked_dir").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Tests -d flag does not remove directories with tracked files.
+async fn test_clean_d_flag_keeps_dirs_with_tracked_files() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    // Create a directory with a tracked file
+    fs::create_dir_all("mixed_dir").unwrap();
+    fs::write("mixed_dir/tracked.txt", "tracked").unwrap();
+    add::execute(AddArgs {
+        pathspec: vec![String::from("mixed_dir/tracked.txt")],
+        all: false,
+        update: false,
+        refresh: false,
+        force: false,
+        verbose: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+
+    // Add an untracked file in the same directory
+    fs::write("mixed_dir/untracked.txt", "untracked").unwrap();
+
+    clean::execute(CleanArgs {
+        dry_run: false,
+        force: true,
+        directories: true,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec![],
+    })
+    .await;
+
+    // Directory should still exist because it has tracked files
+    assert!(std::path::Path::new("mixed_dir").exists());
+    assert!(std::path::Path::new("mixed_dir/tracked.txt").exists());
+    assert!(!std::path::Path::new("mixed_dir/untracked.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Tests -x flag removes ignored files.
+async fn test_clean_x_flag_removes_ignored_files() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    // Create .libraignore and ignored files
+    fs::write(".libraignore", "ignored.txt\n*.log\n").unwrap();
+    add::execute(AddArgs {
+        pathspec: vec![String::from(".libraignore")],
+        all: false,
+        update: false,
+        refresh: false,
+        force: false,
+        verbose: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+
+    fs::write("ignored.txt", "ignored").unwrap();
+    fs::write("debug.log", "log content").unwrap();
+    fs::write("normal.txt", "normal").unwrap();
+
+    clean::execute(CleanArgs {
+        dry_run: false,
+        force: true,
+        directories: false,
+        ignored: true,
+        only_ignored: false,
+        exclude: vec![],
+    })
+    .await;
+
+    assert!(!std::path::Path::new("ignored.txt").exists());
+    assert!(!std::path::Path::new("debug.log").exists());
+    assert!(!std::path::Path::new("normal.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Tests -X flag removes only ignored files.
+async fn test_clean_x_flag_removes_only_ignored_files() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    // Create .libraignore and ignored files
+    fs::write(".libraignore", "ignored.txt\n*.log\n").unwrap();
+    add::execute(AddArgs {
+        pathspec: vec![String::from(".libraignore")],
+        all: false,
+        update: false,
+        refresh: false,
+        force: false,
+        verbose: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+
+    fs::write("ignored.txt", "ignored").unwrap();
+    fs::write("debug.log", "log content").unwrap();
+    fs::write("normal.txt", "normal").unwrap();
+
+    clean::execute(CleanArgs {
+        dry_run: false,
+        force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: true,
+        exclude: vec![],
+    })
+    .await;
+
+    assert!(!std::path::Path::new("ignored.txt").exists());
+    assert!(!std::path::Path::new("debug.log").exists());
+    assert!(std::path::Path::new("normal.txt").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Tests --exclude flag excludes matching patterns.
+async fn test_clean_exclude_flag_excludes_patterns() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    fs::write("important.txt", "important").unwrap();
+    fs::write("temp.log", "log").unwrap();
+    fs::write("data.csv", "data").unwrap();
+
+    clean::execute(CleanArgs {
+        dry_run: false,
+        force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec!["*.txt".to_string()],
+    })
+    .await;
+
+    assert!(std::path::Path::new("important.txt").exists());
+    assert!(!std::path::Path::new("temp.log").exists());
+    assert!(!std::path::Path::new("data.csv").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Tests --exclude with multiple patterns.
+async fn test_clean_exclude_multiple_patterns() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    fs::write("file.txt", "txt").unwrap();
+    fs::write("file.log", "log").unwrap();
+    fs::write("file.csv", "csv").unwrap();
+    fs::write("file.dat", "dat").unwrap();
+
+    clean::execute(CleanArgs {
+        dry_run: false,
+        force: true,
+        directories: false,
+        ignored: false,
+        only_ignored: false,
+        exclude: vec!["*.txt".to_string(), "*.log".to_string()],
+    })
+    .await;
+
+    assert!(std::path::Path::new("file.txt").exists());
+    assert!(std::path::Path::new("file.log").exists());
+    assert!(!std::path::Path::new("file.csv").exists());
+    assert!(!std::path::Path::new("file.dat").exists());
+}
+
+#[tokio::test]
+#[serial]
+/// Tests -x and -X together returns an error.
+async fn test_clean_x_and_x_together_returns_error() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    fs::write("file.txt", "content").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .current_dir(test_dir.path())
+        .args(["clean", "-f", "-x", "-X"])
+        .output()
+        .expect("failed to execute `libra clean`");
+
+    assert_eq!(output.status.code(), Some(129));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cannot use -x and -X together"));
+}
+
+#[tokio::test]
+#[serial]
+/// Tests -d with dry-run shows directories that would be removed.
+async fn test_clean_d_dry_run_shows_directories() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    fs::create_dir_all("untracked_dir").unwrap();
+    fs::write("untracked_dir/file.txt", "content").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
+        .current_dir(test_dir.path())
+        .args(["clean", "-n", "-d"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Would remove untracked_dir"));
+}
+
+#[tokio::test]
+#[serial]
+/// Tests -d with -x removes ignored directories.
+async fn test_clean_dx_removes_ignored_directories() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    // Create .libraignore with directory pattern
+    fs::write(".libraignore", "ignored_dir/\n").unwrap();
+    add::execute(AddArgs {
+        pathspec: vec![String::from(".libraignore")],
+        all: false,
+        update: false,
+        refresh: false,
+        force: false,
+        verbose: false,
+        dry_run: false,
+        ignore_errors: false,
+    })
+    .await;
+
+    fs::create_dir_all("ignored_dir").unwrap();
+    fs::write("ignored_dir/file.txt", "content").unwrap();
+
+    clean::execute(CleanArgs {
+        dry_run: false,
+        force: true,
+        directories: true,
+        ignored: true,
+        only_ignored: false,
+        exclude: vec![],
+    })
+    .await;
+
+    assert!(!std::path::Path::new("ignored_dir").exists());
 }

--- a/tests/command/fetch_test.rs
+++ b/tests/command/fetch_test.rs
@@ -2,11 +2,9 @@
 //!
 //! **Layer:** L1 (most tests). `test_fetch_invalid_remote` is L2 — requires `LIBRA_TEST_GITHUB_TOKEN`.
 
-#[cfg(unix)]
-use std::path::PathBuf;
 use std::{
     fs,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
     time::Duration,
 };


### PR DESCRIPTION
 ## Summary

  Implements missing Git-compatible flags for the clean command:
  - `-d` / `--dir`: Remove untracked directories in addition to files
  - `-x`: Include files ignored by .gitignore/.libraignore
  - `-X`: Remove only files that are ignored
  - `--exclude <pattern>`: Exclude files matching glob patterns (repeatable)

  Closes #363

  ## Changes
  - `src/command/clean.rs`: Added new flags, find_untracked_dirs(), matches_exclude_pattern()
  - `tests/command/clean_test.rs`: 9 new test cases covering all flag combinations
  - `tests/command/fetch_test.rs`: Fixed pre-existing PathBuf import issue

  ## Test plan
  - [x] cargo clippy --lib -- -D warnings passes
  - [x] cargo test --test command_test clean — 31 tests pass
  - [x] cargo +nightly fmt --all formatted

  The pre-task is essentially done:
  - Code implementation complete
  - All 31 clean tests pass
  - Clippy clean
  - Code formatted
  - Issue #363 created
  - Branch pushed to your fork