### PR TITLE
feat(remote): add ls-remote command

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -93,6 +93,8 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTUP_TOOLCHAIN: stable
       LIBRA_SKIP_WEB_BUILD: "1"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_BUILD_JOBS: "1"
 
     steps:
       - name: Checkout repository
@@ -187,6 +189,8 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTUP_TOOLCHAIN: stable
       LIBRA_SKIP_WEB_BUILD: "1"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_BUILD_JOBS: "1"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -208,4 +208,4 @@ jobs:
       # the `compat-live-*` (workflow_dispatch) jobs, which are intentionally not
       # GitHub required-checks.
       - name: Run network-remote tests
-        run: cargo test --all --features test-network
+        run: cargo test --features test-network --test network_remotes_test -- --test-threads=1

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Commands:
   reset        Reset current HEAD to specified state
   rev-parse    Parse and normalize revision names and repository paths
   rev-list     List commit objects reachable from a revision
+  ls-remote    List references in a remote repository
   cherry-pick  Apply the changes introduced by some existing commits
   push         Update remote refs along with associated objects
   fetch        Download objects and refs from another repository
@@ -559,7 +560,6 @@ The following Git top-level commands are currently **not implemented** in Libra 
 - `hash-object` – compute object hash for raw data
 - `verify-pack` – validate pack files
 - `pack-objects` / `unpack-objects` – pack and unpack object collections
-- `ls-remote` – list remote references
 - `remote-show` – show detailed remote info
 - `fetch-pack` / `push-pack` – low-level fetch/push operations
 - `filter-branch` (or `git filter-repo`) – rewrite history

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -80,6 +80,7 @@ Every Libra command accepts the following global flags:
 |---------|-------|-------------|-----|
 | `libra remote` | | Manage remote repositories: add, remove, rename, inspect URLs, prune stale refs | [remote.md](remote.md) |
 | `libra fetch` | | Download objects and update remote-tracking refs from one or all remotes | [fetch.md](fetch.md) |
+| `libra ls-remote` | | List references advertised by a remote repository without fetching objects | [ls-remote.md](ls-remote.md) |
 | `libra push` | | Send local commits and objects to a remote with LFS integration | [push.md](push.md) |
 | `libra pull` | | Fetch and fast-forward merge into the current branch | [pull.md](pull.md) |
 | `libra open` | | Open the repository's remote URL in the system browser | [open.md](open.md) |

--- a/docs/commands/ls-remote.md
+++ b/docs/commands/ls-remote.md
@@ -1,0 +1,64 @@
+# `libra ls-remote`
+
+List references advertised by a remote repository without downloading objects or updating local refs.
+
+```bash
+libra ls-remote [OPTIONS] <repository> [patterns...]
+```
+
+`<repository>` can be a configured remote name when run inside a Libra repository, a URL, or a local Git/Libra repository path.
+
+## Options
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--heads` | Show only `refs/heads/*` branch refs | `libra ls-remote --heads origin` |
+| `-t`, `--tags` | Show only `refs/tags/*` tag refs | `libra ls-remote --tags origin` |
+| `--refs` | Omit `HEAD` and peeled tag refs ending in `^{}` | `libra ls-remote --refs origin` |
+| `patterns...` | Match full ref names or trailing path components; `*` and `?` are supported per path component | `libra ls-remote origin main 'release-*'` |
+
+## Human Output
+
+Each matching ref is printed as:
+
+```text
+<object-id>	<refname>
+```
+
+Example:
+
+```text
+4f3c2d1a...	HEAD
+4f3c2d1a...	refs/heads/main
+```
+
+## JSON Output
+
+With `--json`, output uses the standard command envelope:
+
+```json
+{
+  "ok": true,
+  "command": "ls-remote",
+  "data": {
+    "remote": "origin",
+    "url": "https://example.com/repo.git",
+    "heads_only": false,
+    "tags_only": false,
+    "refs_only": false,
+    "patterns": [],
+    "entries": [
+      {
+        "hash": "4f3c2d1a...",
+        "refname": "refs/heads/main"
+      }
+    ]
+  }
+}
+```
+
+## Notes
+
+- `ls-remote` performs only protocol discovery (`git-upload-pack --advertise-refs` equivalent for local Git repositories).
+- It does not write objects, remote-tracking refs, config, or working-tree files.
+- `--heads` and `--tags` can be combined to show both branch and tag refs while excluding `HEAD`.

--- a/docs/commands/ls-remote.md
+++ b/docs/commands/ls-remote.md
@@ -15,7 +15,7 @@ libra ls-remote [OPTIONS] <repository> [patterns...]
 | `--heads` | Show only `refs/heads/*` branch refs | `libra ls-remote --heads origin` |
 | `-t`, `--tags` | Show only `refs/tags/*` tag refs | `libra ls-remote --tags origin` |
 | `--refs` | Omit `HEAD` and peeled tag refs ending in `^{}` | `libra ls-remote --refs origin` |
-| `patterns...` | Match full ref names or trailing path components; `*` and `?` are supported per path component | `libra ls-remote origin main 'release-*'` |
+| `patterns...` | Match full ref names or trailing path components; `*` and `?` follow Git-style glob behavior and can match `/` | `libra ls-remote origin main 'refs/heads/*'` |
 
 ## Human Output
 

--- a/docs/improvement/compatibility/ci.md
+++ b/docs/improvement/compatibility/ci.md
@@ -90,7 +90,7 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v5
-      - run: cargo test --all --features test-network
+      - run: cargo test --features test-network --test network_remotes_test -- --test-threads=1
 ```
 
 `codeql.yml` matrix 命名：

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -218,6 +218,8 @@ enum Commands {
     Show(command::show::ShowArgs),
     #[command(about = "List references in a local repository")]
     ShowRef(command::show_ref::ShowRefArgs),
+    #[command(about = "List references in a remote repository")]
+    LsRemote(command::ls_remote::LsRemoteArgs),
     #[command(about = "Read or update the symbolic HEAD ref")]
     SymbolicRef(command::symbolic_ref::SymbolicRefArgs),
     #[command(about = "List, create, or delete branches", alias = "br")]
@@ -678,9 +680,11 @@ fn repo_not_found_error(path: Option<&Path>) -> CliError {
 
 fn command_preflight_storage(command: &Commands) -> CliResult<Option<std::path::PathBuf>> {
     match command {
-        Commands::Init(_) | Commands::Clone(_) | Commands::Open(_) | Commands::CodeControl(_) => {
-            Ok(None)
-        }
+        Commands::Init(_)
+        | Commands::Clone(_)
+        | Commands::Open(_)
+        | Commands::CodeControl(_)
+        | Commands::LsRemote(_) => Ok(None),
         #[cfg(unix)]
         Commands::Worktree(command::worktree::WorktreeArgs {
             command: command::worktree::WorktreeSubcommand::Umount { .. },
@@ -893,6 +897,7 @@ pub async fn parse_async(args: Option<&[&str]>) -> CliResult<()> {
         Commands::Shortlog(cmd_args) => command::shortlog::execute_safe(cmd_args, &output).await?,
         Commands::Show(cmd_args) => command::show::execute_safe(cmd_args, &output).await?,
         Commands::ShowRef(cmd_args) => command::show_ref::execute_safe(cmd_args, &output).await?,
+        Commands::LsRemote(cmd_args) => command::ls_remote::execute_safe(cmd_args, &output).await?,
         Commands::SymbolicRef(cmd_args) => {
             command::symbolic_ref::execute_safe(cmd_args, &output).await?
         }

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -658,19 +658,69 @@ fn map_fetch_io_error(
 pub(crate) fn redact_url_credentials(raw: &str) -> String {
     match Url::parse(raw) {
         Ok(mut url) => {
-            let has_password = url.password().is_some();
+            let raw_userinfo = url_userinfo(raw);
+            let has_password = url.password().is_some()
+                || raw_userinfo.is_some_and(|userinfo| userinfo.contains(':'));
             let is_http = matches!(url.scheme(), "http" | "https");
+            let has_http_username =
+                is_http && (!url.username().is_empty() || raw_userinfo.is_some());
             // Redact when there is a password (always sensitive) or when the
             // scheme is HTTP(S) and a username is present (likely a token).
             // For SSH, a bare username like "git" is conventional and harmless.
-            if has_password || (is_http && !url.username().is_empty()) {
+            if has_password || has_http_username {
                 let _ = url.set_username("");
                 let _ = url.set_password(None);
+                return strip_url_userinfo(url.as_str()).unwrap_or_else(|| url.to_string());
             }
             url.to_string()
         }
-        Err(_) => raw.to_string(),
+        Err(_) => {
+            let raw_userinfo = url_userinfo(raw);
+            let is_http = url_scheme(raw).is_some_and(|scheme| {
+                scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https")
+            });
+            if raw_userinfo.is_some_and(|userinfo| userinfo.contains(':'))
+                || (is_http && raw_userinfo.is_some())
+            {
+                strip_url_userinfo(raw).unwrap_or_else(|| raw.to_string())
+            } else {
+                raw.to_string()
+            }
+        }
     }
+}
+
+fn url_scheme(url: &str) -> Option<&str> {
+    url.find("://").map(|scheme_end| &url[..scheme_end])
+}
+
+fn url_userinfo(url: &str) -> Option<&str> {
+    let authority_start = url.find("://")? + 3;
+    let authority_len = url[authority_start..]
+        .find(['/', '?', '#'])
+        .unwrap_or(url.len() - authority_start);
+    let authority_end = authority_start + authority_len;
+    let userinfo_end = url[authority_start..authority_end].rfind('@')?;
+
+    Some(&url[authority_start..authority_start + userinfo_end])
+}
+
+fn strip_url_userinfo(url: &str) -> Option<String> {
+    let authority_start = url.find("://")? + 3;
+    let authority_len = url[authority_start..]
+        .find(['/', '?', '#'])
+        .unwrap_or(url.len() - authority_start);
+    let authority_end = authority_start + authority_len;
+    let userinfo_end = url[authority_start..authority_end].rfind('@')?;
+    let host_start = authority_start + userinfo_end + 1;
+    if host_start == authority_end {
+        return None;
+    }
+
+    let mut redacted = String::with_capacity(url.len());
+    redacted.push_str(&url[..authority_start]);
+    redacted.push_str(&url[host_start..]);
+    Some(redacted)
 }
 
 fn is_timeout_io_error(error: &std::io::Error) -> bool {
@@ -1479,7 +1529,7 @@ mod tests {
 
     use super::{
         FetchError, SSH_KEY_TEMP_FILE_MAX_AGE, cleanup_expired_vault_ssh_temp_files_in,
-        emit_remote_progress, ensure_vault_ssh_tmp_dir,
+        emit_remote_progress, ensure_vault_ssh_tmp_dir, redact_url_credentials,
     };
     use crate::utils::test::ScopedEnvVar;
 
@@ -1516,6 +1566,13 @@ mod tests {
         let captured = capture_remote_progress(b"\rReceiving objects: 42%", false, None);
 
         assert!(captured.is_empty());
+    }
+
+    #[test]
+    fn redact_url_credentials_strips_file_url_userinfo() {
+        let redacted = redact_url_credentials("file://user:secret@example.com/repo.git");
+
+        assert_eq!(redacted, "file://example.com/repo.git");
     }
 
     #[test]

--- a/src/command/ls_remote.rs
+++ b/src/command/ls_remote.rs
@@ -1,0 +1,291 @@
+//! Implements `ls-remote` to list refs advertised by a remote repository.
+
+use std::io::Write;
+
+use clap::Parser;
+use git_internal::errors::GitError;
+use regex::Regex;
+use serde::Serialize;
+
+use crate::{
+    command::fetch::RemoteClient,
+    git_protocol::ServiceType::UploadPack,
+    internal::{config::ConfigKv, protocol::DiscRef},
+    utils::{
+        error::{CliError, CliResult, StableErrorCode},
+        output::{OutputConfig, emit_json_data},
+        util,
+    },
+};
+
+const LS_REMOTE_EXAMPLES: &str = "\
+EXAMPLES:
+  libra ls-remote origin
+  libra ls-remote https://example.com/repo.git
+  libra ls-remote --heads origin main
+  libra --json ls-remote --tags origin";
+
+#[derive(Parser, Debug)]
+#[command(after_help = LS_REMOTE_EXAMPLES)]
+pub struct LsRemoteArgs {
+    /// Show only branch refs (refs/heads/)
+    #[clap(long)]
+    pub heads: bool,
+
+    /// Show only tag refs (refs/tags/)
+    #[clap(long, short = 't')]
+    pub tags: bool,
+
+    /// Do not show HEAD or peeled tag refs (refs ending in ^{})
+    #[clap(long)]
+    pub refs: bool,
+
+    /// Remote name, URL, or local repository path
+    pub repository: String,
+
+    /// Optional ref patterns. Plain names match full refs or path components.
+    pub patterns: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LsRemoteEntry {
+    hash: String,
+    refname: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LsRemoteOutput {
+    remote: String,
+    url: String,
+    heads_only: bool,
+    tags_only: bool,
+    refs_only: bool,
+    patterns: Vec<String>,
+    entries: Vec<LsRemoteEntry>,
+}
+
+#[derive(thiserror::Error, Debug)]
+enum LsRemoteError {
+    #[error("failed to read remote configuration: {0}")]
+    ConfigRead(String),
+    #[error("invalid remote '{spec}': {reason}")]
+    InvalidRemote { spec: String, reason: String },
+    #[error("invalid ref pattern '{pattern}': {reason}")]
+    InvalidPattern { pattern: String, reason: String },
+    #[error("failed to discover references from '{remote}': {source}")]
+    Discovery { remote: String, source: GitError },
+}
+
+impl From<LsRemoteError> for CliError {
+    fn from(error: LsRemoteError) -> Self {
+        match &error {
+            LsRemoteError::ConfigRead(_) => {
+                CliError::fatal(error.to_string()).with_stable_code(StableErrorCode::IoReadFailed)
+            }
+            LsRemoteError::InvalidRemote { .. } | LsRemoteError::InvalidPattern { .. } => {
+                CliError::command_usage(error.to_string())
+                    .with_stable_code(StableErrorCode::CliInvalidTarget)
+                    .with_hint("use 'libra remote -v' to inspect configured remotes")
+            }
+            LsRemoteError::Discovery { source, .. } => match source {
+                GitError::UnAuthorized(_) => CliError::fatal(error.to_string())
+                    .with_stable_code(StableErrorCode::AuthPermissionDenied)
+                    .with_hint("check SSH key / HTTP credentials and repository access rights"),
+                GitError::NetworkError(_) | GitError::IOError(_) => {
+                    CliError::fatal(error.to_string())
+                        .with_stable_code(StableErrorCode::NetworkUnavailable)
+                        .with_hint("check the remote URL and network connectivity")
+                }
+                _ => CliError::fatal(error.to_string())
+                    .with_stable_code(StableErrorCode::NetworkProtocol),
+            },
+        }
+    }
+}
+
+pub async fn execute_safe(args: LsRemoteArgs, output: &OutputConfig) -> CliResult<()> {
+    let data = run_ls_remote(args).await.map_err(CliError::from)?;
+    render_ls_remote_output(&data, output)
+}
+
+async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteError> {
+    let (remote_display, remote_url, remote_name) = resolve_remote(&args.repository).await?;
+    let client = RemoteClient::from_spec_with_remote(&remote_url, remote_name.as_deref()).map_err(
+        |reason| LsRemoteError::InvalidRemote {
+            spec: args.repository.clone(),
+            reason,
+        },
+    )?;
+    let discovery = client
+        .discovery_reference(UploadPack)
+        .await
+        .map_err(|source| LsRemoteError::Discovery {
+            remote: remote_display.clone(),
+            source,
+        })?;
+    let patterns = compile_patterns(&args.patterns)?;
+    let entries = discovery
+        .refs
+        .iter()
+        .filter(|reference| include_reference(reference, &args, &patterns))
+        .map(|reference| LsRemoteEntry {
+            hash: reference._hash.clone(),
+            refname: reference._ref.clone(),
+        })
+        .collect();
+
+    Ok(LsRemoteOutput {
+        remote: remote_display,
+        url: remote_url,
+        heads_only: args.heads,
+        tags_only: args.tags,
+        refs_only: args.refs,
+        patterns: args.patterns,
+        entries,
+    })
+}
+
+async fn resolve_remote(
+    repository: &str,
+) -> Result<(String, String, Option<String>), LsRemoteError> {
+    if util::try_get_storage_path(None).is_ok() {
+        let configured = ConfigKv::remote_config(repository)
+            .await
+            .map_err(|error| LsRemoteError::ConfigRead(error.to_string()))?;
+        if let Some(remote) = configured {
+            return Ok((remote.name.clone(), remote.url, Some(remote.name)));
+        }
+    }
+
+    Ok((repository.to_string(), repository.to_string(), None))
+}
+
+fn compile_patterns(patterns: &[String]) -> Result<Vec<CompiledPattern>, LsRemoteError> {
+    patterns
+        .iter()
+        .map(|pattern| CompiledPattern::new(pattern))
+        .collect()
+}
+
+struct CompiledPattern {
+    raw: String,
+    regex: Option<Regex>,
+}
+
+impl CompiledPattern {
+    fn new(pattern: &str) -> Result<Self, LsRemoteError> {
+        let has_glob = pattern.chars().any(|c| matches!(c, '*' | '?' | '['));
+        let regex = if has_glob {
+            Some(glob_to_regex(pattern)?)
+        } else {
+            None
+        };
+        Ok(Self {
+            raw: pattern.to_string(),
+            regex,
+        })
+    }
+
+    fn matches(&self, refname: &str) -> bool {
+        if let Some(regex) = &self.regex {
+            return regex.is_match(refname);
+        }
+
+        refname == self.raw || refname.ends_with(&format!("/{}", self.raw))
+    }
+}
+
+fn glob_to_regex(pattern: &str) -> Result<Regex, LsRemoteError> {
+    let mut regex = String::from("(^|.*/)");
+    for ch in pattern.chars() {
+        match ch {
+            '*' => regex.push_str("[^/]*"),
+            '?' => regex.push_str("[^/]"),
+            '[' => regex.push('['),
+            ']' => regex.push(']'),
+            '.' | '+' | '(' | ')' | '{' | '}' | '|' | '^' | '$' | '\\' => {
+                regex.push('\\');
+                regex.push(ch);
+            }
+            other => regex.push(other),
+        }
+    }
+    regex.push('$');
+    Regex::new(&regex).map_err(|error| LsRemoteError::InvalidPattern {
+        pattern: pattern.to_string(),
+        reason: error.to_string(),
+    })
+}
+
+fn include_reference(
+    reference: &DiscRef,
+    args: &LsRemoteArgs,
+    patterns: &[CompiledPattern],
+) -> bool {
+    let refname = reference._ref.as_str();
+    if args.refs && (refname == "HEAD" || refname.ends_with("^{}")) {
+        return false;
+    }
+    if args.heads && !refname.starts_with("refs/heads/") {
+        return false;
+    }
+    if args.tags && !refname.starts_with("refs/tags/") {
+        return false;
+    }
+    patterns.is_empty() || patterns.iter().any(|pattern| pattern.matches(refname))
+}
+
+fn render_ls_remote_output(data: &LsRemoteOutput, output: &OutputConfig) -> CliResult<()> {
+    if output.is_json() {
+        emit_json_data("ls-remote", data, output)
+    } else if output.quiet {
+        Ok(())
+    } else {
+        let stdout = std::io::stdout();
+        let mut writer = stdout.lock();
+        for entry in &data.entries {
+            writeln!(writer, "{}\t{}", entry.hash, entry.refname).map_err(|error| {
+                CliError::io(format!("failed to write ls-remote output: {error}"))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompiledPattern, LsRemoteArgs, include_reference};
+    use crate::internal::protocol::DiscRef;
+
+    fn disc_ref(refname: &str) -> DiscRef {
+        DiscRef {
+            _hash: "1111111111111111111111111111111111111111".to_string(),
+            _ref: refname.to_string(),
+        }
+    }
+
+    #[test]
+    fn plain_pattern_matches_ref_tail() {
+        let pattern = CompiledPattern::new("main").unwrap();
+        assert!(pattern.matches("refs/heads/main"));
+        assert!(!pattern.matches("refs/heads/feature"));
+    }
+
+    #[test]
+    fn refs_flag_excludes_head_and_peeled_tags() {
+        let args = LsRemoteArgs {
+            heads: false,
+            tags: false,
+            refs: true,
+            repository: "origin".to_string(),
+            patterns: vec![],
+        };
+        assert!(!include_reference(&disc_ref("HEAD"), &args, &[]));
+        assert!(!include_reference(
+            &disc_ref("refs/tags/v1.0^{}"),
+            &args,
+            &[]
+        ));
+        assert!(include_reference(&disc_ref("refs/tags/v1.0"), &args, &[]));
+    }
+}

--- a/src/command/ls_remote.rs
+++ b/src/command/ls_remote.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use serde::Serialize;
 
 use crate::{
-    command::fetch::RemoteClient,
+    command::fetch::{RemoteClient, redact_url_credentials},
     git_protocol::ServiceType::UploadPack,
     internal::{config::ConfigKv, protocol::DiscRef},
     utils::{
@@ -136,7 +136,7 @@ async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteErr
 
     Ok(LsRemoteOutput {
         remote: remote_display,
-        url: remote_url,
+        url: visible_remote_url(&remote_url),
         heads_only: args.heads,
         tags_only: args.tags,
         refs_only: args.refs,
@@ -165,6 +165,10 @@ fn compile_patterns(patterns: &[String]) -> Result<Vec<CompiledPattern>, LsRemot
         .iter()
         .map(|pattern| CompiledPattern::new(pattern))
         .collect()
+}
+
+fn visible_remote_url(remote_url: &str) -> String {
+    redact_url_credentials(remote_url)
 }
 
 struct CompiledPattern {
@@ -226,11 +230,12 @@ fn include_reference(
     if args.refs && (refname == "HEAD" || refname.ends_with("^{}")) {
         return false;
     }
-    if args.heads && !refname.starts_with("refs/heads/") {
-        return false;
-    }
-    if args.tags && !refname.starts_with("refs/tags/") {
-        return false;
+    if args.heads || args.tags {
+        let matches_heads = args.heads && refname.starts_with("refs/heads/");
+        let matches_tags = args.tags && refname.starts_with("refs/tags/");
+        if !matches_heads && !matches_tags {
+            return false;
+        }
     }
     patterns.is_empty() || patterns.iter().any(|pattern| pattern.matches(refname))
 }
@@ -254,7 +259,7 @@ fn render_ls_remote_output(data: &LsRemoteOutput, output: &OutputConfig) -> CliR
 
 #[cfg(test)]
 mod tests {
-    use super::{CompiledPattern, LsRemoteArgs, include_reference};
+    use super::{CompiledPattern, LsRemoteArgs, include_reference, visible_remote_url};
     use crate::internal::protocol::DiscRef;
 
     fn disc_ref(refname: &str) -> DiscRef {
@@ -287,5 +292,31 @@ mod tests {
             &[]
         ));
         assert!(include_reference(&disc_ref("refs/tags/v1.0"), &args, &[]));
+    }
+
+    #[test]
+    fn heads_and_tags_filters_use_union() {
+        let args = LsRemoteArgs {
+            heads: true,
+            tags: true,
+            refs: false,
+            repository: "origin".to_string(),
+            patterns: vec![],
+        };
+        assert!(include_reference(&disc_ref("refs/heads/main"), &args, &[]));
+        assert!(include_reference(&disc_ref("refs/tags/v1.0"), &args, &[]));
+        assert!(!include_reference(&disc_ref("HEAD"), &args, &[]));
+    }
+
+    #[test]
+    fn visible_remote_url_redacts_http_credentials() {
+        assert_eq!(
+            visible_remote_url("https://token@example.com/repo.git"),
+            "https://example.com/repo.git"
+        );
+        assert_eq!(
+            visible_remote_url("https://user:secret@example.com/repo.git"),
+            "https://example.com/repo.git"
+        );
     }
 }

--- a/src/command/ls_remote.rs
+++ b/src/command/ls_remote.rs
@@ -169,14 +169,14 @@ fn compile_patterns(patterns: &[String]) -> Result<Vec<CompiledPattern>, LsRemot
 }
 
 fn visible_remote_url(remote_url: &str) -> String {
-    redact_url_credentials(remote_url)
+    redact_remote_spec_for_diagnostics(remote_url)
 }
 
 fn visible_remote_display(remote_display: &str, remote_name: Option<&str>) -> String {
     if remote_name.is_some() {
         remote_display.to_string()
     } else {
-        redact_url_credentials(remote_display)
+        redact_remote_spec_for_diagnostics(remote_display)
     }
 }
 
@@ -386,12 +386,32 @@ mod tests {
     }
 
     #[test]
+    fn visible_remote_url_redacts_scp_password() {
+        assert_eq!(
+            visible_remote_url("user:secret@example.com:repo.git"),
+            "[REDACTED]@example.com:repo.git"
+        );
+    }
+
+    #[test]
     fn visible_remote_display_redacts_direct_url_but_preserves_remote_name() {
         assert_eq!(
             visible_remote_display("https://token@example.com/repo.git", None),
             "https://example.com/repo.git"
         );
         assert_eq!(visible_remote_display("origin", Some("origin")), "origin");
+    }
+
+    #[test]
+    fn visible_remote_display_redacts_direct_scp_password() {
+        assert_eq!(
+            visible_remote_display("user:secret@example.com:repo.git", None),
+            "[REDACTED]@example.com:repo.git"
+        );
+        assert_eq!(
+            visible_remote_display("user:secret@example.com:repo.git", Some("origin")),
+            "user:secret@example.com:repo.git"
+        );
     }
 
     #[test]

--- a/src/command/ls_remote.rs
+++ b/src/command/ls_remote.rs
@@ -114,7 +114,7 @@ async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteErr
     let client = RemoteClient::from_spec_with_remote(&remote_url, remote_name.as_deref()).map_err(
         |reason| LsRemoteError::InvalidRemote {
             spec: visible_remote.clone(),
-            reason,
+            reason: sanitize_remote_error_reason(&reason, &remote_url),
         },
     )?;
     let discovery = client
@@ -178,6 +178,38 @@ fn visible_remote_display(remote_display: &str, remote_name: Option<&str>) -> St
     } else {
         redact_url_credentials(remote_display)
     }
+}
+
+fn sanitize_remote_error_reason(reason: &str, remote_url: &str) -> String {
+    let redacted_remote = redact_remote_spec_for_diagnostics(remote_url);
+    let reason = reason.replace(remote_url, &redacted_remote);
+    redact_embedded_remote_credentials(&reason)
+}
+
+fn redact_remote_spec_for_diagnostics(remote_url: &str) -> String {
+    let redacted = redact_url_credentials(remote_url);
+    if redacted != remote_url {
+        return redacted;
+    }
+    redact_embedded_remote_credentials(remote_url)
+}
+
+fn redact_embedded_remote_credentials(input: &str) -> String {
+    let mut redacted = input.to_string();
+
+    if let Ok(url_like_userinfo) = Regex::new(r"(?i)([a-z][a-z0-9+.-]*://)([^\s/@]+@)") {
+        redacted = url_like_userinfo
+            .replace_all(&redacted, "${1}[REDACTED]@")
+            .into_owned();
+    }
+
+    if let Ok(scp_like_userinfo) = Regex::new(r#"(^|[\s'`"])([^\s'`"/@]+:[^\s'`"/@]+@)"#) {
+        redacted = scp_like_userinfo
+            .replace_all(&redacted, "${1}[REDACTED]@")
+            .into_owned();
+    }
+
+    redacted
 }
 
 struct CompiledPattern {
@@ -269,8 +301,8 @@ fn render_ls_remote_output(data: &LsRemoteOutput, output: &OutputConfig) -> CliR
 #[cfg(test)]
 mod tests {
     use super::{
-        CompiledPattern, LsRemoteArgs, include_reference, visible_remote_display,
-        visible_remote_url,
+        CompiledPattern, LsRemoteArgs, include_reference, sanitize_remote_error_reason,
+        visible_remote_display, visible_remote_url,
     };
     use crate::internal::protocol::DiscRef;
 
@@ -339,5 +371,40 @@ mod tests {
             "https://example.com/repo.git"
         );
         assert_eq!(visible_remote_display("origin", Some("origin")), "origin");
+    }
+
+    #[test]
+    fn invalid_remote_reason_redacts_valid_url_credentials() {
+        let remote = "file://user:secret@example.com/repo.git";
+        let reason = format!("invalid file url: {remote}");
+
+        let sanitized = sanitize_remote_error_reason(&reason, remote);
+
+        assert!(!sanitized.contains("user"));
+        assert!(!sanitized.contains("secret"));
+        assert!(sanitized.contains("file://example.com/repo.git"));
+    }
+
+    #[test]
+    fn invalid_remote_reason_redacts_malformed_url_like_credentials() {
+        let remote = "https://user:secret@";
+        let reason = format!("invalid local repository '{remote}': not found");
+
+        let sanitized = sanitize_remote_error_reason(&reason, remote);
+
+        assert!(!sanitized.contains("user"));
+        assert!(!sanitized.contains("secret"));
+        assert!(sanitized.contains("https://[REDACTED]@"));
+    }
+
+    #[test]
+    fn invalid_remote_reason_redacts_scp_like_password_credentials() {
+        let remote = "user:secret@example.com:repo.git";
+        let reason = format!("invalid local repository '{remote}': not found");
+
+        let sanitized = sanitize_remote_error_reason(&reason, remote);
+
+        assert!(!sanitized.contains("user:secret"));
+        assert!(sanitized.contains("[REDACTED]@example.com:repo.git"));
     }
 }

--- a/src/command/ls_remote.rs
+++ b/src/command/ls_remote.rs
@@ -122,7 +122,7 @@ async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteErr
         .await
         .map_err(|source| LsRemoteError::Discovery {
             remote: visible_remote.clone(),
-            source,
+            source: sanitize_discovery_error(source, &remote_url),
         })?;
     let patterns = compile_patterns(&args.patterns)?;
     let entries = discovery
@@ -184,6 +184,25 @@ fn sanitize_remote_error_reason(reason: &str, remote_url: &str) -> String {
     let redacted_remote = redact_remote_spec_for_diagnostics(remote_url);
     let reason = reason.replace(remote_url, &redacted_remote);
     redact_embedded_remote_credentials(&reason)
+}
+
+fn sanitize_discovery_error(source: GitError, remote_url: &str) -> GitError {
+    match source {
+        GitError::NetworkError(message) => {
+            GitError::NetworkError(sanitize_remote_error_reason(&message, remote_url))
+        }
+        GitError::UnAuthorized(message) => {
+            GitError::UnAuthorized(sanitize_remote_error_reason(&message, remote_url))
+        }
+        GitError::CustomError(message) => {
+            GitError::CustomError(sanitize_remote_error_reason(&message, remote_url))
+        }
+        GitError::IOError(error) => GitError::IOError(std::io::Error::new(
+            error.kind(),
+            sanitize_remote_error_reason(&error.to_string(), remote_url),
+        )),
+        other => other,
+    }
 }
 
 fn redact_remote_spec_for_diagnostics(remote_url: &str) -> String {
@@ -300,9 +319,11 @@ fn render_ls_remote_output(data: &LsRemoteOutput, output: &OutputConfig) -> CliR
 
 #[cfg(test)]
 mod tests {
+    use git_internal::errors::GitError;
+
     use super::{
-        CompiledPattern, LsRemoteArgs, include_reference, sanitize_remote_error_reason,
-        visible_remote_display, visible_remote_url,
+        CompiledPattern, LsRemoteArgs, include_reference, sanitize_discovery_error,
+        sanitize_remote_error_reason, visible_remote_display, visible_remote_url,
     };
     use crate::internal::protocol::DiscRef;
 
@@ -406,5 +427,19 @@ mod tests {
 
         assert!(!sanitized.contains("user:secret"));
         assert!(sanitized.contains("[REDACTED]@example.com:repo.git"));
+    }
+
+    #[test]
+    fn discovery_error_redacts_url_credentials_in_source() {
+        let remote = "https://user:secret@example.invalid/repo.git";
+        let source = GitError::NetworkError(format!(
+            "Failed to send request: error sending request for url ({remote}/info/refs?service=git-upload-pack): dns error"
+        ));
+
+        let sanitized = sanitize_discovery_error(source, remote).to_string();
+
+        assert!(!sanitized.contains("user"));
+        assert!(!sanitized.contains("secret"));
+        assert!(sanitized.contains("https://example.invalid/repo.git"));
     }
 }

--- a/src/command/ls_remote.rs
+++ b/src/command/ls_remote.rs
@@ -1,16 +1,20 @@
 //! Implements `ls-remote` to list refs advertised by a remote repository.
 
-use std::io::Write;
+use std::{io::Write, path::Path};
 
 use clap::Parser;
 use git_internal::errors::GitError;
 use regex::Regex;
 use serde::Serialize;
+use url::Url;
 
 use crate::{
     command::fetch::{RemoteClient, redact_url_credentials},
     git_protocol::ServiceType::UploadPack,
-    internal::{config::ConfigKv, protocol::DiscRef},
+    internal::{
+        config::ConfigKv,
+        protocol::{DiscRef, ssh_client::is_ssh_spec},
+    },
     utils::{
         error::{CliError, CliResult, StableErrorCode},
         output::{OutputConfig, emit_json_data},
@@ -149,6 +153,10 @@ async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteErr
 async fn resolve_remote(
     repository: &str,
 ) -> Result<(String, String, Option<String>), LsRemoteError> {
+    if is_explicit_remote_spec(repository) {
+        return Ok((repository.to_string(), repository.to_string(), None));
+    }
+
     if util::try_get_storage_path(None).is_ok() {
         let configured = ConfigKv::remote_config(repository)
             .await
@@ -159,6 +167,20 @@ async fn resolve_remote(
     }
 
     Ok((repository.to_string(), repository.to_string(), None))
+}
+
+fn is_explicit_remote_spec(repository: &str) -> bool {
+    if is_ssh_spec(repository) || Url::parse(repository).is_ok() {
+        return true;
+    }
+
+    let path = Path::new(repository);
+    path.is_absolute()
+        || path.exists()
+        || repository.starts_with("./")
+        || repository.starts_with("../")
+        || repository.contains('/')
+        || repository.contains('\\')
 }
 
 fn compile_patterns(patterns: &[String]) -> Result<Vec<CompiledPattern>, LsRemoteError> {
@@ -263,8 +285,8 @@ fn glob_to_regex(pattern: &str) -> Result<Regex, LsRemoteError> {
     let mut regex = String::from("(^|.*/)");
     for ch in pattern.chars() {
         match ch {
-            '*' => regex.push_str("[^/]*"),
-            '?' => regex.push_str("[^/]"),
+            '*' => regex.push_str(".*"),
+            '?' => regex.push('.'),
             '[' => regex.push('['),
             ']' => regex.push(']'),
             '.' | '+' | '(' | ')' | '{' | '}' | '|' | '^' | '$' | '\\' => {
@@ -319,13 +341,20 @@ fn render_ls_remote_output(data: &LsRemoteOutput, output: &OutputConfig) -> CliR
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use git_internal::errors::GitError;
+    use serial_test::serial;
+    use tempfile::tempdir;
 
     use super::{
-        CompiledPattern, LsRemoteArgs, include_reference, sanitize_discovery_error,
+        CompiledPattern, LsRemoteArgs, include_reference, resolve_remote, sanitize_discovery_error,
         sanitize_remote_error_reason, visible_remote_display, visible_remote_url,
     };
-    use crate::internal::protocol::DiscRef;
+    use crate::{
+        internal::protocol::DiscRef,
+        utils::{test::ChangeDirGuard, util},
+    };
 
     fn disc_ref(refname: &str) -> DiscRef {
         DiscRef {
@@ -339,6 +368,19 @@ mod tests {
         let pattern = CompiledPattern::new("main").unwrap();
         assert!(pattern.matches("refs/heads/main"));
         assert!(!pattern.matches("refs/heads/feature"));
+    }
+
+    #[test]
+    fn glob_pattern_matches_nested_refs_across_slashes() {
+        let full_ref = CompiledPattern::new("refs/heads/*").unwrap();
+        assert!(full_ref.matches("refs/heads/feature/foo"));
+        assert!(!full_ref.matches("refs/tags/feature/foo"));
+
+        let tail_ref = CompiledPattern::new("feature*").unwrap();
+        assert!(tail_ref.matches("refs/heads/feature/foo"));
+
+        let question_ref = CompiledPattern::new("a?b").unwrap();
+        assert!(question_ref.matches("refs/heads/a/b"));
     }
 
     #[test]
@@ -390,6 +432,29 @@ mod tests {
         assert_eq!(
             visible_remote_url("user:secret@example.com:repo.git"),
             "[REDACTED]@example.com:repo.git"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn resolve_direct_url_skips_broken_current_repo_config() {
+        let repo = tempdir().unwrap();
+        let storage = repo.path().join(util::ROOT_DIR);
+        fs::create_dir_all(&storage).unwrap();
+        fs::write(storage.join(util::DATABASE), b"not sqlite").unwrap();
+        let _guard = ChangeDirGuard::new(repo.path());
+
+        let resolved = resolve_remote("https://example.com/repo.git")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resolved,
+            (
+                "https://example.com/repo.git".to_string(),
+                "https://example.com/repo.git".to_string(),
+                None
+            )
         );
     }
 

--- a/src/command/ls_remote.rs
+++ b/src/command/ls_remote.rs
@@ -153,7 +153,7 @@ async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteErr
 async fn resolve_remote(
     repository: &str,
 ) -> Result<(String, String, Option<String>), LsRemoteError> {
-    if is_explicit_remote_spec(repository) {
+    if is_unambiguous_direct_remote_spec(repository) {
         return Ok((repository.to_string(), repository.to_string(), None));
     }
 
@@ -169,18 +169,17 @@ async fn resolve_remote(
     Ok((repository.to_string(), repository.to_string(), None))
 }
 
-fn is_explicit_remote_spec(repository: &str) -> bool {
+fn is_unambiguous_direct_remote_spec(repository: &str) -> bool {
     if is_ssh_spec(repository) || Url::parse(repository).is_ok() {
         return true;
     }
 
     let path = Path::new(repository);
     path.is_absolute()
-        || path.exists()
         || repository.starts_with("./")
         || repository.starts_with("../")
-        || repository.contains('/')
-        || repository.contains('\\')
+        || repository.starts_with(".\\")
+        || repository.starts_with("..\\")
 }
 
 fn compile_patterns(patterns: &[String]) -> Result<Vec<CompiledPattern>, LsRemoteError> {

--- a/src/command/ls_remote.rs
+++ b/src/command/ls_remote.rs
@@ -110,6 +110,7 @@ pub async fn execute_safe(args: LsRemoteArgs, output: &OutputConfig) -> CliResul
 
 async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteError> {
     let (remote_display, remote_url, remote_name) = resolve_remote(&args.repository).await?;
+    let visible_remote = visible_remote_display(&remote_display, remote_name.as_deref());
     let client = RemoteClient::from_spec_with_remote(&remote_url, remote_name.as_deref()).map_err(
         |reason| LsRemoteError::InvalidRemote {
             spec: args.repository.clone(),
@@ -120,7 +121,7 @@ async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteErr
         .discovery_reference(UploadPack)
         .await
         .map_err(|source| LsRemoteError::Discovery {
-            remote: remote_display.clone(),
+            remote: visible_remote.clone(),
             source,
         })?;
     let patterns = compile_patterns(&args.patterns)?;
@@ -135,7 +136,7 @@ async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteErr
         .collect();
 
     Ok(LsRemoteOutput {
-        remote: remote_display,
+        remote: visible_remote,
         url: visible_remote_url(&remote_url),
         heads_only: args.heads,
         tags_only: args.tags,
@@ -169,6 +170,14 @@ fn compile_patterns(patterns: &[String]) -> Result<Vec<CompiledPattern>, LsRemot
 
 fn visible_remote_url(remote_url: &str) -> String {
     redact_url_credentials(remote_url)
+}
+
+fn visible_remote_display(remote_display: &str, remote_name: Option<&str>) -> String {
+    if remote_name.is_some() {
+        remote_display.to_string()
+    } else {
+        redact_url_credentials(remote_display)
+    }
 }
 
 struct CompiledPattern {
@@ -259,7 +268,10 @@ fn render_ls_remote_output(data: &LsRemoteOutput, output: &OutputConfig) -> CliR
 
 #[cfg(test)]
 mod tests {
-    use super::{CompiledPattern, LsRemoteArgs, include_reference, visible_remote_url};
+    use super::{
+        CompiledPattern, LsRemoteArgs, include_reference, visible_remote_display,
+        visible_remote_url,
+    };
     use crate::internal::protocol::DiscRef;
 
     fn disc_ref(refname: &str) -> DiscRef {
@@ -318,5 +330,14 @@ mod tests {
             visible_remote_url("https://user:secret@example.com/repo.git"),
             "https://example.com/repo.git"
         );
+    }
+
+    #[test]
+    fn visible_remote_display_redacts_direct_url_but_preserves_remote_name() {
+        assert_eq!(
+            visible_remote_display("https://token@example.com/repo.git", None),
+            "https://example.com/repo.git"
+        );
+        assert_eq!(visible_remote_display("origin", Some("origin")), "origin");
     }
 }

--- a/src/command/ls_remote.rs
+++ b/src/command/ls_remote.rs
@@ -113,7 +113,7 @@ async fn run_ls_remote(args: LsRemoteArgs) -> Result<LsRemoteOutput, LsRemoteErr
     let visible_remote = visible_remote_display(&remote_display, remote_name.as_deref());
     let client = RemoteClient::from_spec_with_remote(&remote_url, remote_name.as_deref()).map_err(
         |reason| LsRemoteError::InvalidRemote {
-            spec: args.repository.clone(),
+            spec: visible_remote.clone(),
             reason,
         },
     )?;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -33,6 +33,7 @@ pub mod index_pack;
 pub mod init;
 pub mod lfs;
 pub mod log;
+pub mod ls_remote;
 pub mod merge;
 pub mod mv;
 pub mod open;

--- a/src/command/worktree.rs
+++ b/src/command/worktree.rs
@@ -860,13 +860,12 @@ fn repair_worktrees() -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use tempfile::tempdir;
 
     use super::*;
 
-    #[cfg(unix)]
     #[test]
     fn umount_fuse_path_cleans_task_worktree_root_without_repo() {
         let temp = tempdir().expect("create temp dir");

--- a/src/internal/ai/orchestrator/workspace.rs
+++ b/src/internal/ai/orchestrator/workspace.rs
@@ -81,7 +81,9 @@ struct FuseTaskWorktreeBackend {
 struct TaskWorktreePaths {
     cleanup_root: PathBuf,
     workspace_root: PathBuf,
+    #[cfg(unix)]
     lower_root: PathBuf,
+    #[cfg(unix)]
     upper_root: PathBuf,
 }
 
@@ -192,6 +194,8 @@ pub(crate) fn prepare_task_worktree(
     fuse_state: &FuseProvisionState,
 ) -> io::Result<(TaskWorktree, FuseAttemptOutcome)> {
     let baseline = snapshot_workspace(main_working_dir)?;
+    #[cfg(not(unix))]
+    let _ = fuse_state;
 
     #[cfg(unix)]
     {
@@ -263,7 +267,9 @@ fn task_worktree_paths(main_working_dir: &Path, task_id: Uuid, backend: &str) ->
     ));
     TaskWorktreePaths {
         workspace_root: cleanup_root.join("workspace"),
+        #[cfg(unix)]
         lower_root: cleanup_root.join("lower"),
+        #[cfg(unix)]
         upper_root: cleanup_root.join("upper"),
         cleanup_root,
     }
@@ -1827,7 +1833,9 @@ mod tests {
 
         assert_eq!(paths.cleanup_root.parent(), Some(expected_base.as_path()));
         assert_eq!(paths.workspace_root, paths.cleanup_root.join("workspace"));
+        #[cfg(unix)]
         assert_eq!(paths.lower_root, paths.cleanup_root.join("lower"));
+        #[cfg(unix)]
         assert_eq!(paths.upper_root, paths.cleanup_root.join("upper"));
 
         let cleanup_name = paths.cleanup_root.file_name().unwrap().to_string_lossy();

--- a/src/internal/ai/sandbox/runtime.rs
+++ b/src/internal/ai/sandbox/runtime.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 
 use super::{SandboxPermissions, SandboxPolicy};
+#[cfg(unix)]
 use crate::utils::fuse;
 
 pub const LIBRA_SANDBOX_NETWORK_DISABLED_ENV_VAR: &str = "LIBRA_SANDBOX_NETWORK_DISABLED";
@@ -102,16 +103,25 @@ fn apply_fuse_workspace_env_overrides(
     env: &mut HashMap<String, String>,
     ambient_cargo_target_dir_is_set: bool,
 ) {
-    if env.contains_key(CARGO_TARGET_DIR_ENV_VAR) || ambient_cargo_target_dir_is_set {
+    #[cfg(not(unix))]
+    {
+        let _ = (cwd, env, ambient_cargo_target_dir_is_set);
         return;
     }
-    let Some(target_dir) = fuse::fuse_workspace_cargo_target_dir(cwd) else {
-        return;
-    };
-    env.insert(
-        CARGO_TARGET_DIR_ENV_VAR.to_string(),
-        target_dir.to_string_lossy().into_owned(),
-    );
+
+    #[cfg(unix)]
+    {
+        if env.contains_key(CARGO_TARGET_DIR_ENV_VAR) || ambient_cargo_target_dir_is_set {
+            return;
+        }
+        let Some(target_dir) = fuse::fuse_workspace_cargo_target_dir(cwd) else {
+            return;
+        };
+        env.insert(
+            CARGO_TARGET_DIR_ENV_VAR.to_string(),
+            target_dir.to_string_lossy().into_owned(),
+        );
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/internal/ai/sandbox/runtime.rs
+++ b/src/internal/ai/sandbox/runtime.rs
@@ -106,7 +106,6 @@ fn apply_fuse_workspace_env_overrides(
     #[cfg(not(unix))]
     {
         let _ = (cwd, env, ambient_cargo_target_dir_is_set);
-        return;
     }
 
     #[cfg(unix)]

--- a/src/internal/protocol/https_client.rs
+++ b/src/internal/protocol/https_client.rs
@@ -7,8 +7,6 @@ use git_internal::errors::GitError;
 use reqwest::{Body, RequestBuilder, Response, StatusCode, header::CONTENT_TYPE};
 use url::Url;
 
-#[cfg(all(test, feature = "test-network"))]
-use super::DiscRef;
 use super::{
     DiscoveryResult, FetchStream, ProtocolClient, generate_upload_pack_content,
     parse_discovered_references,
@@ -212,80 +210,5 @@ impl HttpsClient {
                 .body(data.clone())
         })
         .await
-    }
-}
-#[cfg(all(test, feature = "test-network"))]
-mod tests {
-    use super::*;
-    use crate::{git_protocol::ServiceType::UploadPack, utils::test::init_debug_logger};
-
-    #[cfg(feature = "test-network")]
-    #[tokio::test]
-    async fn test_discover_reference_upload() {
-        if std::env::var("LIBRA_TEST_GITHUB_TOKEN").map_or(true, |v| v.is_empty()) {
-            eprintln!("skipped (LIBRA_TEST_GITHUB_TOKEN not set)");
-            return;
-        }
-        init_debug_logger();
-
-        let test_repo = "https://github.com/web3infra-foundation/mega.git/";
-
-        let client = HttpsClient::from_url(&Url::parse(test_repo).unwrap());
-        let discovery = client.discovery_reference(UploadPack).await;
-        if let Err(e) = discovery {
-            tracing::error!("{:?}", e);
-            panic!();
-        } else {
-            let discovery = discovery.unwrap();
-            println!("refs count: {:?}", discovery.refs.len());
-            println!("example: {:?}", discovery.refs.get(1));
-        }
-    }
-
-    #[cfg(feature = "test-network")]
-    #[tokio::test]
-    async fn test_post_git_upload_pack_() {
-        if std::env::var("LIBRA_TEST_GITHUB_TOKEN").map_or(true, |v| v.is_empty()) {
-            eprintln!("skipped (LIBRA_TEST_GITHUB_TOKEN not set)");
-            return;
-        }
-        init_debug_logger();
-
-        let test_repo = "https://github.com/web3infra-foundation/mega/";
-        let client = HttpsClient::from_url(&Url::parse(test_repo).unwrap());
-        let discovery = client.discovery_reference(UploadPack).await.unwrap();
-        let refs: Vec<DiscRef> = discovery
-            .refs
-            .iter()
-            .filter(|r| r._ref.starts_with("refs/heads"))
-            .cloned()
-            .collect();
-        tracing::info!("refs: {:?}", refs);
-
-        let want: Vec<String> = refs.iter().map(|r| r._hash.clone()).collect();
-
-        let have = vec!["81a162e7b725bbad2adfe01879fd57e0119406b9".to_string()];
-        let mut result_stream = client.fetch_objects(&have, &want, None).await.unwrap();
-
-        let mut buffer = vec![];
-        while let Some(item) = result_stream.next().await {
-            let item = item.unwrap();
-            buffer.extend(item);
-        }
-
-        // pase pkt line
-        if let Some(pack_pos) = buffer.windows(4).position(|w| w == b"PACK") {
-            tracing::info!("pack data found at: {}", pack_pos);
-            let readable_output = std::str::from_utf8(&buffer[..pack_pos]).unwrap();
-            tracing::debug!("stdout readable: \n{}", readable_output);
-            tracing::info!("pack length: {}", buffer.len() - pack_pos);
-            assert!(buffer[pack_pos..pack_pos + 4].eq(b"PACK"));
-        } else {
-            tracing::error!(
-                "no pack data found, stdout is :\n{}",
-                std::str::from_utf8(&buffer).unwrap()
-            );
-            panic!("no pack data found");
-        }
     }
 }

--- a/src/internal/protocol/lfs_client.rs
+++ b/src/internal/protocol/lfs_client.rs
@@ -745,38 +745,6 @@ mod tests {
         println!("{:?}", serde_json::to_string(&vars).unwrap());
     }
 
-    #[cfg(feature = "test-network")]
-    #[tokio::test]
-    async fn test_github_batch() {
-        if std::env::var("LIBRA_TEST_GITHUB_TOKEN").map_or(true, |v| v.is_empty()) {
-            eprintln!("skipped (LIBRA_TEST_GITHUB_TOKEN not set)");
-            return;
-        }
-        let batch_request = BatchRequest {
-            operation: Operation::Download,
-            transfers: vec![lfs::LFS_TRANSFER_API.to_string()],
-            objects: vec![RequestObject {
-                oid: "01cb1483670f1c497412f25f9f8f7dde31a8fab0960291035af03939ae1dfa6b".to_string(),
-                size: 104103,
-                ..Default::default()
-            }],
-            hash_algo: lfs::LFS_HASH_ALGO.to_string(),
-        };
-        let lfs_client = LFSClient::from_url(
-            &Url::parse("https://github.com/web3infra-foundation/mega.git").unwrap(),
-        );
-        let request = lfs_client
-            .client
-            .post(lfs_client.batch_url.clone())
-            .json(&batch_request)
-            .headers(lfs::LFS_HEADERS.clone());
-        println!("Request {request:?}");
-        let response = request.send().await.unwrap();
-        let text = response.text().await.unwrap();
-        println!("Text {text:?}");
-        let _resp = serde_json::from_str::<LfsBatchResponse>(&text).unwrap();
-    }
-
     #[tokio::test]
     async fn test_push_object() {
         if std::env::var("LIBRA_TEST_MEGA_SERVER").map_or(true, |v| v.is_empty()) {

--- a/src/internal/protocol/local_client.rs
+++ b/src/internal/protocol/local_client.rs
@@ -34,7 +34,7 @@ use super::{
 use crate::{
     command::{load_object, log::get_reachable_commits},
     git_protocol::ServiceType,
-    internal::{branch::Branch, config::ConfigKv, head::Head, protocol::DiscRef, reflog},
+    internal::{branch::Branch, config::ConfigKv, head::Head, protocol::DiscRef, reflog, tag},
     utils::{object_ext::TreeExt, util::cur_dir},
 };
 
@@ -268,11 +268,18 @@ impl LocalClient {
                     let head_commit = Head::current_commit_result()
                         .await
                         .map_err(|error| GitError::CustomError(error.to_string()))?;
+                    let tags = tag::list()
+                        .await
+                        .map_err(|error| GitError::CustomError(error.to_string()))?;
                     Ok(DiscoveryResult {
                         refs: local_branches
                             .into_iter()
                             .chain(remote_branches)
                             .map(Into::into)
+                            .chain(tags.into_iter().map(|tag| DiscRef {
+                                _hash: tag_object_hash(&tag.object),
+                                _ref: format!("refs/tags/{}", tag.name),
+                            }))
                             .chain(head_commit.map(|x| x.to_string()).map(|hash| DiscRef {
                                 _hash: hash,
                                 _ref: reflog::HEAD.to_string(),
@@ -493,6 +500,15 @@ impl LocalClient {
                 .await
             }
         }
+    }
+}
+
+fn tag_object_hash(object: &tag::TagObject) -> String {
+    match object {
+        tag::TagObject::Commit(commit) => commit.id.to_string(),
+        tag::TagObject::Tag(tag) => tag.id.to_string(),
+        tag::TagObject::Tree(tree) => tree.id.to_string(),
+        tag::TagObject::Blob(blob) => blob.id.to_string(),
     }
 }
 

--- a/src/internal/protocol/local_client.rs
+++ b/src/internal/protocol/local_client.rs
@@ -276,10 +276,7 @@ impl LocalClient {
                             .into_iter()
                             .chain(remote_branches)
                             .map(Into::into)
-                            .chain(tags.into_iter().map(|tag| DiscRef {
-                                _hash: tag_object_hash(&tag.object),
-                                _ref: format!("refs/tags/{}", tag.name),
-                            }))
+                            .chain(tags.into_iter().flat_map(tag_refs))
                             .chain(head_commit.map(|x| x.to_string()).map(|hash| DiscRef {
                                 _hash: hash,
                                 _ref: reflog::HEAD.to_string(),
@@ -510,6 +507,23 @@ fn tag_object_hash(object: &tag::TagObject) -> String {
         tag::TagObject::Tree(tree) => tree.id.to_string(),
         tag::TagObject::Blob(blob) => blob.id.to_string(),
     }
+}
+
+fn tag_refs(tag: tag::Tag) -> Vec<DiscRef> {
+    let refname = format!("refs/tags/{}", tag.name);
+    let mut refs = vec![DiscRef {
+        _hash: tag_object_hash(&tag.object),
+        _ref: refname.clone(),
+    }];
+
+    if let tag::TagObject::Tag(tag_object) = tag.object {
+        refs.push(DiscRef {
+            _hash: tag_object.object_hash.to_string(),
+            _ref: format!("{refname}^{{}}"),
+        });
+    }
+
+    refs
 }
 
 #[cfg(test)]

--- a/src/internal/protocol/local_client.rs
+++ b/src/internal/protocol/local_client.rs
@@ -13,7 +13,7 @@ use bytes::Bytes;
 use futures_util::stream::{self, StreamExt};
 use git_internal::{
     errors::GitError,
-    hash::get_hash_kind,
+    hash::{HashKind, get_hash_kind, set_hash_kind},
     internal::{
         metadata::{EntryMeta, MetaAttached},
         object::{
@@ -34,8 +34,14 @@ use super::{
 use crate::{
     command::{load_object, log::get_reachable_commits},
     git_protocol::ServiceType,
-    internal::{branch::Branch, config::ConfigKv, head::Head, protocol::DiscRef, reflog, tag},
-    utils::{object_ext::TreeExt, util::cur_dir},
+    internal::{
+        branch::Branch, config::ConfigKv, db::get_db_conn_instance_for_path, head::Head,
+        protocol::DiscRef, reflog, tag,
+    },
+    utils::{
+        object_ext::TreeExt,
+        util::{DATABASE, cur_dir},
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -107,6 +113,24 @@ impl Drop for RepoCurrentDirGuard {
                 "failed to restore working directory after local protocol operation"
             );
         }
+    }
+}
+
+struct HashKindRestoreGuard {
+    previous: HashKind,
+}
+
+impl HashKindRestoreGuard {
+    fn switch_to(hash_kind: HashKind) -> Self {
+        let previous = get_hash_kind();
+        set_hash_kind(hash_kind);
+        Self { previous }
+    }
+}
+
+impl Drop for HashKindRestoreGuard {
+    fn drop(&mut self) {
+        set_hash_kind(self.previous);
     }
 }
 
@@ -217,6 +241,37 @@ impl LocalClient {
         &self.repo_path
     }
 
+    async fn repo_hash_kind(&self) -> Result<HashKind, String> {
+        let db_path = self.repo_path.join(DATABASE);
+        let db_conn = get_db_conn_instance_for_path(&db_path)
+            .await
+            .map_err(|error| {
+                format!(
+                    "failed to open local repository database '{}': {error}",
+                    db_path.display()
+                )
+            })?;
+        let object_format = ConfigKv::get_with_conn(&db_conn, "core.objectformat")
+            .await
+            .map_err(|error| {
+                format!(
+                    "failed to read core.objectformat from local repository '{}': {error}",
+                    db_path.display()
+                )
+            })?
+            .map(|entry| entry.value)
+            .unwrap_or_else(|| "sha1".to_string());
+
+        match object_format.as_str() {
+            "sha1" => Ok(HashKind::Sha1),
+            "sha256" => Ok(HashKind::Sha256),
+            _ => Err(format!(
+                "unsupported object format '{object_format}' in local repository '{}'",
+                db_path.display()
+            )),
+        }
+    }
+
     pub async fn discovery_reference(
         &self,
         service: ServiceType,
@@ -250,6 +305,10 @@ impl LocalClient {
             }
             RepoType::LibraRepo => {
                 self.with_repo_current_dir(|| async {
+                    let repo_hash_kind =
+                        self.repo_hash_kind().await.map_err(GitError::CustomError)?;
+                    let _hash_guard = HashKindRestoreGuard::switch_to(repo_hash_kind);
+
                     let local_branches = Branch::list_branches_result(None)
                         .await
                         .map_err(|error| GitError::CustomError(error.to_string()))?;
@@ -283,7 +342,7 @@ impl LocalClient {
                             }))
                             .collect::<Vec<_>>(),
                         capabilities: vec![],
-                        hash_kind: get_hash_kind(),
+                        hash_kind: repo_hash_kind,
                     })
                 })
                 .await
@@ -333,6 +392,9 @@ impl LocalClient {
             }
             RepoType::LibraRepo => {
                 self.with_repo_current_dir(|| async {
+                    let repo_hash_kind = self.repo_hash_kind().await.map_err(IoError::other)?;
+                    let _hash_guard = HashKindRestoreGuard::switch_to(repo_hash_kind);
+
                     let mut seen = HashSet::new();
                     have.iter().for_each(|hash| {
                         seen.insert(hash.clone());

--- a/src/internal/protocol/local_client.rs
+++ b/src/internal/protocol/local_client.rs
@@ -330,12 +330,16 @@ impl LocalClient {
                     let tags = tag::list()
                         .await
                         .map_err(|error| GitError::CustomError(error.to_string()))?;
+                    let mut tag_references = Vec::new();
+                    for tag in tags {
+                        tag_references.extend(tag_refs(tag).await?);
+                    }
                     Ok(DiscoveryResult {
                         refs: local_branches
                             .into_iter()
                             .chain(remote_branches)
                             .map(Into::into)
-                            .chain(tags.into_iter().flat_map(tag_refs))
+                            .chain(tag_references)
                             .chain(head_commit.map(|x| x.to_string()).map(|hash| DiscRef {
                                 _hash: hash,
                                 _ref: reflog::HEAD.to_string(),
@@ -571,7 +575,7 @@ fn tag_object_hash(object: &tag::TagObject) -> String {
     }
 }
 
-fn tag_refs(tag: tag::Tag) -> Vec<DiscRef> {
+async fn tag_refs(tag: tag::Tag) -> Result<Vec<DiscRef>, GitError> {
     let refname = format!("refs/tags/{}", tag.name);
     let mut refs = vec![DiscRef {
         _hash: tag_object_hash(&tag.object),
@@ -580,12 +584,33 @@ fn tag_refs(tag: tag::Tag) -> Vec<DiscRef> {
 
     if let tag::TagObject::Tag(tag_object) = tag.object {
         refs.push(DiscRef {
-            _hash: tag_object.object_hash.to_string(),
+            _hash: peel_tag_object_hash(tag_object.object_hash, &refname).await?,
             _ref: format!("{refname}^{{}}"),
         });
     }
 
-    refs
+    Ok(refs)
+}
+
+async fn peel_tag_object_hash(
+    mut object_hash: git_internal::hash::ObjectHash,
+    refname: &str,
+) -> Result<String, GitError> {
+    let mut seen = HashSet::new();
+    loop {
+        if !seen.insert(object_hash) {
+            return Err(GitError::CustomError(format!(
+                "detected cycle while peeling tag '{refname}'"
+            )));
+        }
+
+        match tag::load_object_trait(&object_hash).await? {
+            tag::TagObject::Commit(commit) => return Ok(commit.id.to_string()),
+            tag::TagObject::Tree(tree) => return Ok(tree.id.to_string()),
+            tag::TagObject::Blob(blob) => return Ok(blob.id.to_string()),
+            tag::TagObject::Tag(tag) => object_hash = tag.object_hash,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/internal/protocol/mod.rs
+++ b/src/internal/protocol/mod.rs
@@ -32,6 +32,16 @@ pub struct DiscoveredReference {
     pub(crate) _ref: String,
 }
 
+impl DiscoveredReference {
+    pub fn hash(&self) -> &str {
+        &self._hash
+    }
+
+    pub fn name(&self) -> &str {
+        &self._ref
+    }
+}
+
 pub type DiscRef = DiscoveredReference;
 
 pub type FetchStream = futures_util::stream::BoxStream<'static, Result<Bytes, std::io::Error>>;

--- a/tests/command/branch_test.rs
+++ b/tests/command/branch_test.rs
@@ -20,6 +20,8 @@
 
 use std::collections::HashSet;
 #[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 use git_internal::hash::{ObjectHash, get_hash_kind};

--- a/tests/command/branch_test.rs
+++ b/tests/command/branch_test.rs
@@ -18,9 +18,9 @@
 
 #![cfg(test)]
 
+use std::collections::HashSet;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::{collections::HashSet, fs};
 
 use git_internal::hash::{ObjectHash, get_hash_kind};
 use libra::internal::config::ConfigKv;

--- a/tests/command/fetch_test.rs
+++ b/tests/command/fetch_test.rs
@@ -2,11 +2,9 @@
 //!
 //! **Layer:** L1 (most tests). `test_fetch_invalid_remote` is L2 — requires `LIBRA_TEST_GITHUB_TOKEN`.
 
-#[cfg(unix)]
-use std::path::PathBuf;
 use std::{
     fs,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
     time::Duration,
 };

--- a/tests/command/ls_remote_test.rs
+++ b/tests/command/ls_remote_test.rs
@@ -1,0 +1,91 @@
+use super::*;
+
+#[test]
+fn ls_remote_local_path_lists_head_and_branch_outside_repo() {
+    let remote = create_committed_repo_via_cli();
+    let outside = tempdir().expect("failed to create outside cwd");
+
+    let remote_path = remote.path().to_string_lossy().to_string();
+    let output = run_libra_command(&["ls-remote", &remote_path], outside.path());
+    assert_cli_success(
+        &output,
+        "ls-remote local path should succeed outside a repo",
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\tHEAD"),
+        "expected HEAD in ls-remote output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("\trefs/heads/main"),
+        "expected main branch in ls-remote output, got: {stdout}"
+    );
+}
+
+#[test]
+fn ls_remote_resolves_configured_remote_name() {
+    let remote = create_committed_repo_via_cli();
+    let local = create_committed_repo_via_cli();
+    let remote_path = remote.path().to_string_lossy().to_string();
+
+    let output = run_libra_command(&["remote", "add", "origin", &remote_path], local.path());
+    assert_cli_success(&output, "remote add should succeed");
+
+    let output = run_libra_command(&["ls-remote", "origin"], local.path());
+    assert_cli_success(&output, "ls-remote origin should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\trefs/heads/main"),
+        "expected configured remote main branch, got: {stdout}"
+    );
+}
+
+#[test]
+fn ls_remote_heads_pattern_filters_refs() {
+    let remote = create_committed_repo_via_cli();
+    let outside = tempdir().expect("failed to create outside cwd");
+    let remote_path = remote.path().to_string_lossy().to_string();
+
+    let output = run_libra_command(
+        &["ls-remote", "--heads", &remote_path, "main"],
+        outside.path(),
+    );
+    assert_cli_success(&output, "ls-remote --heads main should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\trefs/heads/main"),
+        "expected main branch in filtered output, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\tHEAD"),
+        "--heads should not include HEAD, got: {stdout}"
+    );
+}
+
+#[test]
+fn ls_remote_json_reports_entries() {
+    let remote = create_committed_repo_via_cli();
+    let outside = tempdir().expect("failed to create outside cwd");
+    let remote_path = remote.path().to_string_lossy().to_string();
+
+    let output = run_libra_command(
+        &["--json=compact", "ls-remote", &remote_path],
+        outside.path(),
+    );
+    assert_cli_success(&output, "json ls-remote should succeed");
+
+    let json = parse_json_stdout(&output);
+    assert_eq!(json["command"], "ls-remote");
+    let entries = json["data"]["entries"]
+        .as_array()
+        .expect("entries should be an array");
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry["refname"] == "refs/heads/main"),
+        "expected refs/heads/main in entries: {json}"
+    );
+}

--- a/tests/command/ls_remote_test.rs
+++ b/tests/command/ls_remote_test.rs
@@ -66,6 +66,53 @@ fn ls_remote_heads_pattern_filters_refs() {
 }
 
 #[test]
+fn ls_remote_heads_and_tags_returns_union() {
+    let remote = create_committed_repo_via_cli();
+    let outside = tempdir().expect("failed to create outside cwd");
+    let tag_output = run_libra_command(&["tag", "v1.0"], remote.path());
+    assert_cli_success(&tag_output, "tag creation should succeed");
+    let remote_path = remote.path().to_string_lossy().to_string();
+
+    let output = run_libra_command(
+        &["ls-remote", "--heads", "--tags", &remote_path],
+        outside.path(),
+    );
+    assert_cli_success(&output, "ls-remote --heads --tags should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\trefs/heads/main"),
+        "expected branch ref in union output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("\trefs/tags/v1.0"),
+        "expected tag ref in union output, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("\tHEAD"),
+        "combined heads/tags filters should exclude HEAD, got: {stdout}"
+    );
+}
+
+#[test]
+fn ls_remote_tags_lists_local_libra_tags() {
+    let remote = create_committed_repo_via_cli();
+    let outside = tempdir().expect("failed to create outside cwd");
+    let tag_output = run_libra_command(&["tag", "v1.0"], remote.path());
+    assert_cli_success(&tag_output, "tag creation should succeed");
+    let remote_path = remote.path().to_string_lossy().to_string();
+
+    let output = run_libra_command(&["ls-remote", "--tags", &remote_path], outside.path());
+    assert_cli_success(&output, "ls-remote --tags should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\trefs/tags/v1.0"),
+        "expected local Libra tag ref, got: {stdout}"
+    );
+}
+
+#[test]
 fn ls_remote_json_reports_entries() {
     let remote = create_committed_repo_via_cli();
     let outside = tempdir().expect("failed to create outside cwd");

--- a/tests/command/ls_remote_test.rs
+++ b/tests/command/ls_remote_test.rs
@@ -96,6 +96,30 @@ fn ls_remote_resolves_configured_remote_name() {
 }
 
 #[test]
+fn ls_remote_prefers_configured_remote_over_same_named_local_directory() {
+    let remote = create_committed_repo_via_cli();
+    let local = create_committed_repo_via_cli();
+    let remote_path = remote.path().to_string_lossy().to_string();
+
+    let output = run_libra_command(&["remote", "add", "origin", &remote_path], local.path());
+    assert_cli_success(&output, "remote add should succeed");
+    std::fs::create_dir(local.path().join("origin"))
+        .expect("failed to create path-shaped remote-name directory");
+
+    let output = run_libra_command(&["ls-remote", "origin"], local.path());
+    assert_cli_success(
+        &output,
+        "ls-remote origin should resolve the configured remote",
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\trefs/heads/main"),
+        "expected configured remote refs despite local origin/ directory, got: {stdout}"
+    );
+}
+
+#[test]
 fn ls_remote_heads_pattern_filters_refs() {
     let remote = create_committed_repo_via_cli();
     let outside = tempdir().expect("failed to create outside cwd");

--- a/tests/command/ls_remote_test.rs
+++ b/tests/command/ls_remote_test.rs
@@ -24,6 +24,39 @@ fn ls_remote_local_path_lists_head_and_branch_outside_repo() {
 }
 
 #[test]
+fn ls_remote_local_sha256_repo_lists_refs_outside_repo() {
+    let remote = tempdir().expect("failed to create remote repository root");
+    let output = run_libra_command(&["init", "--object-format", "sha256"], remote.path());
+    assert_cli_success(&output, "failed to initialize sha256 repository");
+    configure_identity_via_cli(remote.path());
+
+    std::fs::write(remote.path().join("tracked.txt"), "tracked\n")
+        .expect("failed to create tracked file");
+    let output = run_libra_command(&["add", ".libraignore", "tracked.txt"], remote.path());
+    assert_cli_success(&output, "failed to add tracked file");
+    let output = run_libra_command(&["commit", "-m", "base", "--no-verify"], remote.path());
+    assert_cli_success(&output, "failed to create initial commit");
+
+    let outside = tempdir().expect("failed to create outside cwd");
+    let remote_path = remote.path().to_string_lossy().to_string();
+    let output = run_libra_command(&["ls-remote", &remote_path], outside.path());
+    assert_cli_success(
+        &output,
+        "ls-remote local sha256 path should succeed outside a repo",
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let main_line = stdout
+        .lines()
+        .find(|line| line.ends_with("\trefs/heads/main"))
+        .unwrap_or_else(|| panic!("expected main branch in ls-remote output, got: {stdout}"));
+    let (hash, _) = main_line
+        .split_once('\t')
+        .expect("ls-remote ref line should be tab-separated");
+    assert_eq!(hash.len(), 64, "expected sha256 ref hash, got: {stdout}");
+}
+
+#[test]
 fn ls_remote_resolves_configured_remote_name() {
     let remote = create_committed_repo_via_cli();
     let local = create_committed_repo_via_cli();

--- a/tests/command/ls_remote_test.rs
+++ b/tests/command/ls_remote_test.rs
@@ -113,6 +113,40 @@ fn ls_remote_tags_lists_local_libra_tags() {
 }
 
 #[test]
+fn ls_remote_tags_lists_peeled_annotated_tag_for_local_libra_remote() {
+    let remote = create_committed_repo_via_cli();
+    let outside = tempdir().expect("failed to create outside cwd");
+    let tag_output = run_libra_command(&["tag", "-m", "Release v1.0", "v1.0"], remote.path());
+    assert_cli_success(&tag_output, "annotated tag creation should succeed");
+    let remote_path = remote.path().to_string_lossy().to_string();
+
+    let output = run_libra_command(&["ls-remote", "--tags", &remote_path], outside.path());
+    assert_cli_success(&output, "ls-remote --tags should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\trefs/tags/v1.0\n"),
+        "expected annotated tag object ref, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("\trefs/tags/v1.0^{}\n"),
+        "expected peeled annotated tag ref, got: {stdout}"
+    );
+
+    let refs_output = run_libra_command(
+        &["ls-remote", "--tags", "--refs", &remote_path],
+        outside.path(),
+    );
+    assert_cli_success(&refs_output, "ls-remote --tags --refs should succeed");
+
+    let refs_stdout = String::from_utf8_lossy(&refs_output.stdout);
+    assert!(
+        !refs_stdout.contains("\trefs/tags/v1.0^{}\n"),
+        "--refs should suppress peeled annotated tag refs, got: {refs_stdout}"
+    );
+}
+
+#[test]
 fn ls_remote_json_reports_entries() {
     let remote = create_committed_repo_via_cli();
     let outside = tempdir().expect("failed to create outside cwd");

--- a/tests/command/ls_remote_test.rs
+++ b/tests/command/ls_remote_test.rs
@@ -1,3 +1,23 @@
+use std::{path::Path, str::FromStr};
+
+use git_internal::{
+    hash::{HashKind, ObjectHash, set_hash_kind_for_test},
+    internal::object::{
+        signature::{Signature, SignatureType},
+        tag::Tag as GitTag,
+        types::ObjectType,
+    },
+};
+use libra::{
+    command::save_object_to_storage,
+    internal::{db::get_db_conn_instance_for_path, head::Head, model::reference},
+    utils::{
+        client_storage::ClientStorage,
+        util::{DATABASE, ROOT_DIR},
+    },
+};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+
 use super::*;
 
 #[test]
@@ -177,6 +197,85 @@ fn ls_remote_tags_lists_peeled_annotated_tag_for_local_libra_remote() {
         !refs_stdout.contains("\trefs/tags/v1.0^{}\n"),
         "--refs should suppress peeled annotated tag refs, got: {refs_stdout}"
     );
+}
+
+#[test]
+fn ls_remote_tags_recursively_peels_nested_annotated_tag_for_local_libra_remote() {
+    let remote = create_committed_repo_via_cli();
+    let outside = tempdir().expect("failed to create outside cwd");
+    let tag_output = run_libra_command(&["tag", "-m", "Inner release", "inner"], remote.path());
+    assert_cli_success(&tag_output, "inner annotated tag creation should succeed");
+    let (commit_hash, inner_tag_hash, outer_tag_hash) = create_nested_annotated_tag(remote.path());
+    let remote_path = remote.path().to_string_lossy().to_string();
+
+    let output = run_libra_command(&["ls-remote", "--tags", &remote_path], outside.path());
+    assert_cli_success(&output, "ls-remote --tags should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!("{outer_tag_hash}\trefs/tags/outer\n")),
+        "expected outer annotated tag object ref, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("{commit_hash}\trefs/tags/outer^{{}}\n")),
+        "expected outer peeled ref to final commit, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains(&format!("{inner_tag_hash}\trefs/tags/outer^{{}}\n")),
+        "peeled ref should not stop at the inner tag object, got: {stdout}"
+    );
+}
+
+fn create_nested_annotated_tag(repo: &Path) -> (String, String, String) {
+    let _hash_guard = set_hash_kind_for_test(HashKind::Sha1);
+    let runtime = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    runtime.block_on(async {
+        let storage_path = repo.join(ROOT_DIR);
+        let db = get_db_conn_instance_for_path(&storage_path.join(DATABASE))
+            .await
+            .expect("failed to open repository database");
+        let inner_ref = reference::Entity::find()
+            .filter(reference::Column::Name.eq("refs/tags/inner"))
+            .filter(reference::Column::Kind.eq(reference::ConfigKind::Tag))
+            .one(&db)
+            .await
+            .expect("failed to query inner tag ref")
+            .expect("inner tag ref should exist");
+        let inner_tag_hash = inner_ref.commit.expect("inner tag should have a target");
+        let inner_tag_id = ObjectHash::from_str(&inner_tag_hash).expect("inner tag hash is valid");
+        let commit_hash = Head::current_commit_result_with_conn(&db)
+            .await
+            .expect("failed to resolve HEAD commit")
+            .expect("expected committed HEAD")
+            .to_string();
+        let outer_tag = GitTag::new(
+            inner_tag_id,
+            ObjectType::Tag,
+            "outer".to_string(),
+            Signature::new(
+                SignatureType::Tagger,
+                "Test User".to_string(),
+                "test@example.com".to_string(),
+            ),
+            "Outer release".to_string(),
+        );
+        let storage = ClientStorage::init(storage_path.join("objects"));
+        save_object_to_storage(&storage, &outer_tag, &outer_tag.id)
+            .expect("failed to save outer tag object");
+        let outer_tag_hash = outer_tag.id.to_string();
+        reference::ActiveModel {
+            name: Set(Some("refs/tags/outer".to_string())),
+            kind: Set(reference::ConfigKind::Tag),
+            commit: Set(Some(outer_tag_hash.clone())),
+            remote: Set(None),
+            ..Default::default()
+        }
+        .insert(&db)
+        .await
+        .expect("failed to insert outer tag ref");
+
+        (commit_hash, inner_tag_hash, outer_tag_hash)
+    })
 }
 
 #[test]

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -286,6 +286,7 @@ mod init_separate_libra_dir_test;
 mod init_test;
 mod lfs_test;
 mod log_test;
+mod ls_remote_test;
 mod merge_test;
 mod mv_test;
 mod open_test;

--- a/tests/command/reset_test.rs
+++ b/tests/command/reset_test.rs
@@ -14,7 +14,7 @@ use libra::{
         status::{changes_to_be_committed, changes_to_be_staged},
     },
     internal::{branch::Branch as InternalBranch, config::ConfigKv},
-    utils::{error::StableErrorCode, test::setup_with_new_libra_in},
+    utils::test::setup_with_new_libra_in,
 };
 
 use super::*;

--- a/tests/command/reset_test.rs
+++ b/tests/command/reset_test.rs
@@ -6,6 +6,8 @@ use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+#[cfg(unix)]
+use libra::utils::error::StableErrorCode;
 use libra::{
     command::{
         branch::{self, BranchArgs},
@@ -16,8 +18,6 @@ use libra::{
     internal::{branch::Branch as InternalBranch, config::ConfigKv},
     utils::test::setup_with_new_libra_in,
 };
-#[cfg(unix)]
-use libra::utils::error::StableErrorCode;
 
 use super::*;
 

--- a/tests/command/reset_test.rs
+++ b/tests/command/reset_test.rs
@@ -16,6 +16,8 @@ use libra::{
     internal::{branch::Branch as InternalBranch, config::ConfigKv},
     utils::test::setup_with_new_libra_in,
 };
+#[cfg(unix)]
+use libra::utils::error::StableErrorCode;
 
 use super::*;
 

--- a/tests/command/tag_test.rs
+++ b/tests/command/tag_test.rs
@@ -12,10 +12,7 @@ use libra::{
         branch::Branch, config::ConfigKv, db::get_db_conn_instance, model::reference,
         tag as internal_tag,
     },
-    utils::{
-        path,
-        test::{ChangeDirGuard, setup_with_new_libra_in},
-    },
+    utils::test::{ChangeDirGuard, setup_with_new_libra_in},
 };
 use sea_orm::{ActiveModelTrait, Set};
 use serial_test::serial;

--- a/tests/command/tag_test.rs
+++ b/tests/command/tag_test.rs
@@ -14,6 +14,8 @@ use libra::{
     },
     utils::test::{ChangeDirGuard, setup_with_new_libra_in},
 };
+#[cfg(unix)]
+use libra::utils::path;
 use sea_orm::{ActiveModelTrait, Set};
 use serial_test::serial;
 use tempfile::tempdir;

--- a/tests/command/tag_test.rs
+++ b/tests/command/tag_test.rs
@@ -6,6 +6,8 @@ use std::collections::HashSet;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+#[cfg(unix)]
+use libra::utils::path;
 use libra::{
     command::tag::{self, TagArgs},
     internal::{
@@ -14,8 +16,6 @@ use libra::{
     },
     utils::test::{ChangeDirGuard, setup_with_new_libra_in},
 };
-#[cfg(unix)]
-use libra::utils::path;
 use sea_orm::{ActiveModelTrait, Set};
 use serial_test::serial;
 use tempfile::tempdir;

--- a/tests/network_remotes_test.rs
+++ b/tests/network_remotes_test.rs
@@ -14,7 +14,7 @@ use libra::{
 use url::Url;
 
 fn network_tests_enabled() -> bool {
-    std::env::var("LIBRA_TEST_GITHUB_TOKEN").map_or(false, |value| !value.is_empty())
+    std::env::var("LIBRA_TEST_GITHUB_TOKEN").is_ok_and(|value| !value.is_empty())
 }
 
 #[tokio::test]

--- a/tests/network_remotes_test.rs
+++ b/tests/network_remotes_test.rs
@@ -13,17 +13,8 @@ use libra::{
 };
 use url::Url;
 
-fn network_tests_enabled() -> bool {
-    std::env::var("LIBRA_TEST_GITHUB_TOKEN").is_ok_and(|value| !value.is_empty())
-}
-
 #[tokio::test]
 async fn https_discovery_upload_pack_lists_refs() {
-    if !network_tests_enabled() {
-        eprintln!("skipped (LIBRA_TEST_GITHUB_TOKEN not set)");
-        return;
-    }
-
     let client = HttpsClient::from_url(
         &Url::parse("https://github.com/web3infra-foundation/mega.git/").unwrap(),
     );
@@ -44,11 +35,6 @@ async fn https_discovery_upload_pack_lists_refs() {
 
 #[tokio::test]
 async fn https_upload_pack_returns_pack_data() {
-    if !network_tests_enabled() {
-        eprintln!("skipped (LIBRA_TEST_GITHUB_TOKEN not set)");
-        return;
-    }
-
     let client = HttpsClient::from_url(
         &Url::parse("https://github.com/web3infra-foundation/mega/").unwrap(),
     );
@@ -84,11 +70,6 @@ async fn https_upload_pack_returns_pack_data() {
 
 #[tokio::test]
 async fn github_lfs_batch_download_returns_response() {
-    if !network_tests_enabled() {
-        eprintln!("skipped (LIBRA_TEST_GITHUB_TOKEN not set)");
-        return;
-    }
-
     let batch_request = BatchRequest {
         operation: Operation::Download,
         transfers: vec![lfs::LFS_TRANSFER_API.to_string()],

--- a/tests/network_remotes_test.rs
+++ b/tests/network_remotes_test.rs
@@ -42,17 +42,16 @@ async fn https_upload_pack_returns_pack_data() {
         .discovery_reference(UploadPack)
         .await
         .expect("discovery should succeed against public GitHub repo");
-    let want: Vec<String> = discovery
+    let main_ref = discovery
         .refs
         .iter()
-        .filter(|reference| reference.name().starts_with("refs/heads/"))
-        .map(|reference| reference.hash().to_string())
-        .collect();
-    assert!(!want.is_empty(), "expected branch refs to fetch");
+        .find(|reference| reference.name() == "refs/heads/main")
+        .expect("expected stable main branch ref");
+    let want = vec![main_ref.hash().to_string()];
 
-    let have = vec!["81a162e7b725bbad2adfe01879fd57e0119406b9".to_string()];
+    let have = Vec::new();
     let mut result_stream = client
-        .fetch_objects(&have, &want, None)
+        .fetch_objects(&have, &want, Some(1))
         .await
         .expect("upload-pack request should succeed");
 

--- a/tests/network_remotes_test.rs
+++ b/tests/network_remotes_test.rs
@@ -1,0 +1,119 @@
+#![cfg(feature = "test-network")]
+
+use futures_util::StreamExt;
+use libra::{
+    git_protocol::ServiceType::UploadPack,
+    internal::protocol::{
+        ProtocolClient,
+        https_client::HttpsClient,
+        lfs_client::{LFSClient, LfsBatchResponse},
+    },
+    lfs_structs::{BatchRequest, Operation, RequestObject},
+    utils::lfs,
+};
+use url::Url;
+
+fn network_tests_enabled() -> bool {
+    std::env::var("LIBRA_TEST_GITHUB_TOKEN").map_or(false, |value| !value.is_empty())
+}
+
+#[tokio::test]
+async fn https_discovery_upload_pack_lists_refs() {
+    if !network_tests_enabled() {
+        eprintln!("skipped (LIBRA_TEST_GITHUB_TOKEN not set)");
+        return;
+    }
+
+    let client = HttpsClient::from_url(
+        &Url::parse("https://github.com/web3infra-foundation/mega.git/").unwrap(),
+    );
+    let discovery = client
+        .discovery_reference(UploadPack)
+        .await
+        .expect("discovery should succeed against public GitHub repo");
+
+    assert!(!discovery.refs.is_empty(), "expected advertised refs");
+    assert!(
+        discovery
+            .refs
+            .iter()
+            .any(|reference| reference.name().starts_with("refs/heads/")),
+        "expected at least one branch ref"
+    );
+}
+
+#[tokio::test]
+async fn https_upload_pack_returns_pack_data() {
+    if !network_tests_enabled() {
+        eprintln!("skipped (LIBRA_TEST_GITHUB_TOKEN not set)");
+        return;
+    }
+
+    let client = HttpsClient::from_url(
+        &Url::parse("https://github.com/web3infra-foundation/mega/").unwrap(),
+    );
+    let discovery = client
+        .discovery_reference(UploadPack)
+        .await
+        .expect("discovery should succeed against public GitHub repo");
+    let want: Vec<String> = discovery
+        .refs
+        .iter()
+        .filter(|reference| reference.name().starts_with("refs/heads/"))
+        .map(|reference| reference.hash().to_string())
+        .collect();
+    assert!(!want.is_empty(), "expected branch refs to fetch");
+
+    let have = vec!["81a162e7b725bbad2adfe01879fd57e0119406b9".to_string()];
+    let mut result_stream = client
+        .fetch_objects(&have, &want, None)
+        .await
+        .expect("upload-pack request should succeed");
+
+    let mut buffer = Vec::new();
+    while let Some(item) = result_stream.next().await {
+        buffer.extend(item.expect("pack stream chunk should be readable"));
+    }
+
+    let pack_pos = buffer
+        .windows(4)
+        .position(|window| window == b"PACK")
+        .expect("upload-pack response should contain pack data");
+    assert_eq!(&buffer[pack_pos..pack_pos + 4], b"PACK");
+}
+
+#[tokio::test]
+async fn github_lfs_batch_download_returns_response() {
+    if !network_tests_enabled() {
+        eprintln!("skipped (LIBRA_TEST_GITHUB_TOKEN not set)");
+        return;
+    }
+
+    let batch_request = BatchRequest {
+        operation: Operation::Download,
+        transfers: vec![lfs::LFS_TRANSFER_API.to_string()],
+        objects: vec![RequestObject {
+            oid: "01cb1483670f1c497412f25f9f8f7dde31a8fab0960291035af03939ae1dfa6b".to_string(),
+            size: 104103,
+            ..Default::default()
+        }],
+        hash_algo: lfs::LFS_HASH_ALGO.to_string(),
+    };
+    let lfs_client = LFSClient::from_url(
+        &Url::parse("https://github.com/web3infra-foundation/mega.git").unwrap(),
+    );
+    let response = lfs_client
+        .client
+        .post(lfs_client.batch_url.clone())
+        .json(&batch_request)
+        .headers(lfs::LFS_HEADERS.clone())
+        .send()
+        .await
+        .expect("LFS batch request should complete");
+    let text = response
+        .text()
+        .await
+        .expect("LFS response body is readable");
+    let _response: LfsBatchResponse =
+        serde_json::from_str(&text).expect("LFS batch response should be JSON");
+}


### PR DESCRIPTION
## Summary

  Adds `libra ls-remote` for listing refs advertised by a remote repository without fetching objects or updating local
  refs.