### PR TITLE
feat(verify-pack): validate pack indexes

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -74,7 +74,7 @@ batch document.
 | agent | intentionally-different | Libra external-agent capture extension, not a Git command |
 | hooks | intentionally-different | Hidden compatibility entry for hook configs installed by `libra agent enable` |
 | cat-file | supported | `-e` does not support JSON |
-| verify-pack | supported | validates `.idx` files against matching `.pack` archives |
+| verify-pack | partial | validates one `.idx` file against a matching `.pack`; Git's multi-index form and `-s` / `--stat-only` are not exposed |
 | index-pack | supported | hidden plumbing command |
 | checkout | partial | branch compatibility surface (visible in top-level help); prefer `switch` for branches and `restore` for files. JSON/machine success output and render split supported; typed `CheckoutError` pending |
 | bisect | partial | `start` / `bad` / `good` / `reset` / `skip` / `log` / `run` / `view` supported; `replay` (see [docs/improvement/compatibility/declined.md#d6-bisect-replay](docs/improvement/compatibility/declined.md#d6-bisect-replay)) / `terms` (see [docs/improvement/compatibility/declined.md#d7-bisect-terms](docs/improvement/compatibility/declined.md#d7-bisect-terms)) deferred |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -74,6 +74,7 @@ batch document.
 | agent | intentionally-different | Libra external-agent capture extension, not a Git command |
 | hooks | intentionally-different | Hidden compatibility entry for hook configs installed by `libra agent enable` |
 | cat-file | supported | `-e` does not support JSON |
+| verify-pack | supported | validates `.idx` files against matching `.pack` archives |
 | index-pack | supported | hidden plumbing command |
 | checkout | partial | branch compatibility surface (visible in top-level help); prefer `switch` for branches and `restore` for files. JSON/machine success output and render split supported; typed `CheckoutError` pending |
 | bisect | partial | `start` / `bad` / `good` / `reset` / `skip` / `log` / `run` / `view` supported; `replay` (see [docs/improvement/compatibility/declined.md#d6-bisect-replay](docs/improvement/compatibility/declined.md#d6-bisect-replay)) / `terms` (see [docs/improvement/compatibility/declined.md#d7-bisect-terms](docs/improvement/compatibility/declined.md#d7-bisect-terms)) deferred |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Commands:
   publish       Materialise the read-only Cloudflare Worker template; sync/deploy are not yet implemented
   agent         Manage external-agent capture (Claude Code, Gemini, ...)
   cat-file      Provide content, type or size info for repository objects
+  verify-pack   Validate pack index files against pack archives
   checkout      Branch compatibility surface; prefer 'switch' for branches and 'restore' for files
   bisect        Use binary search to find the commit that introduced a bug
   help          Print this message or the help of the given subcommand(s)
@@ -580,7 +581,6 @@ The following Git top-level commands are currently **not implemented** in Libra 
 - `fsck` – verify repository integrity
 - `maintenance` – periodic maintenance tasks
 - `hash-object` – compute object hash for raw data
-- `verify-pack` – validate pack files
 - `pack-objects` / `unpack-objects` – pack and unpack object collections
 - `remote-show` – show detailed remote info
 - `fetch-pack` / `push-pack` – low-level fetch/push operations

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -113,6 +113,7 @@ Every Libra command accepts the following global flags:
 | Command | Alias | Description | Doc |
 |---------|-------|-------------|-----|
 | `libra cat-file` | | Inspect Git objects and AI objects by type, size, or pretty-printed content | [cat-file.md](cat-file.md) |
+| `libra verify-pack` | | Validate pack index files against their pack archives | [verify-pack.md](verify-pack.md) |
 | `libra show-ref` | | List local refs (branches, tags, HEAD) and their object IDs | [show-ref.md](show-ref.md) |
 | `libra symbolic-ref` | | Read or update the symbolic HEAD ref | [symbolic-ref.md](symbolic-ref.md) |
 | `libra index-pack` | | Build a `.idx` pack index file for an existing `.pack` archive (hidden) | [index-pack.md](index-pack.md) |

--- a/docs/commands/index-pack.md
+++ b/docs/commands/index-pack.md
@@ -111,13 +111,12 @@ exposes it for three reasons:
    `index-pack` to exist. Providing it means Libra can be a drop-in replacement
    in CI pipelines that call plumbing commands.
 
-### Why no `--verify`?
+### Why a separate `verify-pack` command?
 
-Git's `index-pack --verify` re-reads an existing `.idx` file and checks it
-against the pack for consistency. Libra does not yet implement this because the
-primary use case (generating indices) is covered, and verification can be done
-by regenerating the index and comparing checksums. A dedicated `--verify` flag
-is a natural future addition once there is demand from agent or CI workflows.
+Git exposes verification through both `verify-pack` and some `index-pack`
+workflows. Libra keeps index generation and verification separate:
+`index-pack` writes an index, while [`verify-pack`](verify-pack.md) performs a
+read-only consistency check between an existing `.idx` and its `.pack`.
 
 ### Why limited index versions?
 
@@ -144,7 +143,7 @@ algorithms.
 | Build index from pack | `libra index-pack <file>` | `git index-pack <file>` | N/A (jj uses its own storage) |
 | Custom output path | `-o <path>` | `-o <path>` | N/A |
 | Index version | `--index-version 1\|2` (default 1) | `--index-version <N>[,<offset>]` (default 2) | N/A |
-| Verify existing index | Not implemented | `--verify` | N/A |
+| Verify existing index | `libra verify-pack <idx>` | `verify-pack` / `index-pack --verify` | N/A |
 | `--stdin` (read pack from stdin) | Not implemented | Yes | N/A |
 | `--fix-thin` (add bases for thin packs) | Not implemented | Yes | N/A |
 | `--keep` (create .keep file) | Not implemented | Yes | N/A |

--- a/docs/commands/verify-pack.md
+++ b/docs/commands/verify-pack.md
@@ -23,8 +23,9 @@ decodes the corresponding pack file, and verifies that both files agree on:
 By default the pack path is derived by replacing the index file extension with
 `.pack`. Use `--pack <PACK_FILE>` when the pack archive lives elsewhere.
 The command does not require a Libra repository. When run inside a repository,
-it uses that repository's object format; outside a repository, it defaults to
-SHA-1.
+it uses that repository's object format. Outside a repository, version 2 index
+files infer SHA-1 vs SHA-256 from the index layout; version 1 indexes are SHA-1
+only.
 
 ## Options
 
@@ -32,7 +33,7 @@ SHA-1.
 |------|-------|-------------|---------|
 | `<IDX_FILE>` | | Pack index file to verify | Required |
 | `--pack <PATH>` | | Pack archive to verify against | `<IDX_FILE>` with `.pack` extension |
-| `--verbose` | `-v` | Print each indexed object and offset | Off |
+| `--verbose` | `-v` | Print each indexed object using Git-compatible verbose fields | Off |
 | `--json` | | Emit a structured JSON envelope | Off |
 | `--machine` | | Emit the same envelope as one compact JSON line | Off |
 
@@ -53,13 +54,17 @@ Successful non-verbose verification prints one summary line:
 objects/pack/pack-abc123.idx: ok
 ```
 
-Verbose mode prints indexed objects before the summary line. Version 2 indexes
-also include each object's CRC32:
+Verbose mode prints indexed objects before the summary line using Git's base
+field layout:
 
 ```text
-3b18e512dba79e4c8300dd08aeb37f8e728b8dad 12 0x1a2b3c4d
+3b18e512dba79e4c8300dd08aeb37f8e728b8dad blob 12 21 48
 objects/pack/pack-abc123.idx: ok
 ```
+
+The fields are `<oid> <type> <size> <size-in-pack> <offset>`. CRC32 values for
+version 2 indexes are validated and remain available in structured output, but
+are not printed in human verbose mode.
 
 ## Structured Output
 
@@ -79,8 +84,8 @@ objects/pack/pack-abc123.idx: ok
 }
 ```
 
-When `--verbose` is combined with `--json`, `data.objects[]` contains
-`oid`, `offset`, and optional `crc32`.
+When `--verbose` is combined with `--json`, `data.objects[]` contains `oid`,
+`object_type`, `size`, `size_in_pack`, `offset`, and optional `crc32`.
 
 ## Compatibility
 

--- a/docs/commands/verify-pack.md
+++ b/docs/commands/verify-pack.md
@@ -27,6 +27,9 @@ it uses that repository's object format. Outside a repository, version 2 index
 files infer SHA-1 vs SHA-256 from the index layout; version 1 indexes are SHA-1
 only.
 
+Compatibility note: this command currently accepts one `<IDX_FILE>` per
+invocation and does not expose Git's `-s` / `--stat-only` form.
+
 ## Options
 
 | Flag | Short | Description | Default |
@@ -91,8 +94,9 @@ When `--verbose` is combined with `--json`, `data.objects[]` contains `oid`,
 
 | Feature | Libra | Git | jj |
 |---------|-------|-----|----|
-| Verify pack index | `libra verify-pack <idx>` | `git verify-pack <idx>` | N/A |
+| Verify pack index | `libra verify-pack <idx>` | `git verify-pack <idx>...` | N/A |
 | Verbose objects | `-v` / `--verbose` | `-v` | N/A |
+| Stat-only mode | Unsupported | `-s` / `--stat-only` | N/A |
 | Explicit pack path | `--pack <path>` | N/A | N/A |
 | JSON output | `--json` / `--machine` | N/A | N/A |
 | Version 1 index | Supported for SHA-1 repositories | Supported | N/A |

--- a/docs/commands/verify-pack.md
+++ b/docs/commands/verify-pack.md
@@ -1,0 +1,101 @@
+# `libra verify-pack`
+
+Validate a Git pack index (`.idx`) against its matching pack archive (`.pack`).
+
+## Synopsis
+
+```bash
+libra verify-pack [OPTIONS] <IDX_FILE>
+```
+
+## Description
+
+`libra verify-pack` is a read-only plumbing command. It parses the pack index,
+decodes the corresponding pack file, and verifies that both files agree on:
+
+- index version and structural layout
+- fanout table monotonicity and object-name sorting
+- index checksum
+- pack checksum stored in the index trailer
+- object count, object IDs, and offsets
+- CRC32 values for version 2 indexes
+
+By default the pack path is derived by replacing the index file extension with
+`.pack`. Use `--pack <PACK_FILE>` when the pack archive lives elsewhere.
+
+## Options
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `<IDX_FILE>` | | Pack index file to verify | Required |
+| `--pack <PATH>` | | Pack archive to verify against | `<IDX_FILE>` with `.pack` extension |
+| `--verbose` | `-v` | Print each indexed object and offset | Off |
+| `--json` | | Emit a structured JSON envelope | Off |
+| `--machine` | | Emit the same envelope as one compact JSON line | Off |
+
+## Examples
+
+```bash
+libra verify-pack objects/pack/pack-abc123.idx
+libra verify-pack --pack /tmp/pack-abc123.pack /tmp/pack-abc123.idx
+libra verify-pack -v pack-abc123.idx
+libra verify-pack pack-abc123.idx --json
+```
+
+## Human Output
+
+Successful non-verbose verification prints one summary line:
+
+```text
+objects/pack/pack-abc123.idx: ok
+```
+
+Verbose mode prints indexed objects before the summary line. Version 2 indexes
+also include each object's CRC32:
+
+```text
+3b18e512dba79e4c8300dd08aeb37f8e728b8dad 12 0x1a2b3c4d
+objects/pack/pack-abc123.idx: ok
+```
+
+## Structured Output
+
+```json
+{
+  "ok": true,
+  "command": "verify-pack",
+  "data": {
+    "idx_file": "objects/pack/pack-abc123.idx",
+    "pack_file": "objects/pack/pack-abc123.pack",
+    "index_version": 2,
+    "object_count": 42,
+    "pack_hash": "0123456789abcdef0123456789abcdef01234567",
+    "index_hash": "89abcdef0123456789abcdef0123456789abcdef",
+    "verified": true
+  }
+}
+```
+
+When `--verbose` is combined with `--json`, `data.objects[]` contains
+`oid`, `offset`, and optional `crc32`.
+
+## Compatibility
+
+| Feature | Libra | Git | jj |
+|---------|-------|-----|----|
+| Verify pack index | `libra verify-pack <idx>` | `git verify-pack <idx>` | N/A |
+| Verbose objects | `-v` / `--verbose` | `-v` | N/A |
+| Explicit pack path | `--pack <path>` | N/A | N/A |
+| JSON output | `--json` / `--machine` | N/A | N/A |
+| Version 1 index | Supported for SHA-1 repositories | Supported | N/A |
+| Version 2 index | Supported | Supported | N/A |
+
+## Error Handling
+
+| Scenario | StableErrorCode | Exit |
+|----------|-----------------|------|
+| Index file cannot be opened | `LBR-IO-001` | 128 |
+| Pack file cannot be opened | `LBR-IO-001` | 128 |
+| Index is malformed | `LBR-REPO-002` | 128 |
+| Pack is malformed | `LBR-REPO-002` | 128 |
+| Index and pack disagree | `LBR-REPO-002` | 128 |

--- a/docs/commands/verify-pack.md
+++ b/docs/commands/verify-pack.md
@@ -22,6 +22,8 @@ decodes the corresponding pack file, and verifies that both files agree on:
 
 By default the pack path is derived by replacing the index file extension with
 `.pack`. Use `--pack <PACK_FILE>` when the pack archive lives elsewhere.
+The command does not require a Libra repository and defaults to SHA-1 when no
+repository object format is available.
 
 ## Options
 

--- a/docs/commands/verify-pack.md
+++ b/docs/commands/verify-pack.md
@@ -22,8 +22,9 @@ decodes the corresponding pack file, and verifies that both files agree on:
 
 By default the pack path is derived by replacing the index file extension with
 `.pack`. Use `--pack <PACK_FILE>` when the pack archive lives elsewhere.
-The command does not require a Libra repository and defaults to SHA-1 when no
-repository object format is available.
+The command does not require a Libra repository. When run inside a repository,
+it uses that repository's object format; outside a repository, it defaults to
+SHA-1.
 
 ## Options
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -253,8 +253,6 @@ enum Commands {
     Describe(command::describe::DescribeArgs),
     #[command(about = "Provide content, type or size info for repository objects")]
     CatFile(command::cat_file::CatFileArgs),
-    #[command(about = "Compute Git-compatible object IDs")]
-    HashObject(command::hash_object::HashObjectArgs),
     #[command(about = "Validate pack index files against pack archives")]
     VerifyPack(command::verify_pack::VerifyPackArgs),
 
@@ -723,6 +721,14 @@ impl CommandPreflight {
         }
     }
 
+    fn sha1_without_repo() -> Self {
+        Self {
+            storage: None,
+            check_schema: false,
+            set_hash_kind: true,
+        }
+    }
+
     fn repo(storage: std::path::PathBuf) -> Self {
         Self {
             storage: Some(storage),
@@ -748,6 +754,7 @@ fn command_preflight(command: &Commands) -> CliResult<CommandPreflight> {
         | Commands::CodeControl(_)
         | Commands::LsRemote(_)
         | Commands::Sandbox(_) => Ok(CommandPreflight::none()),
+        Commands::VerifyPack(_) => Ok(CommandPreflight::sha1_without_repo()),
         #[cfg(unix)]
         Commands::Worktree(command::worktree::WorktreeArgs {
             command: command::worktree::WorktreeSubcommand::Umount { .. },
@@ -954,6 +961,8 @@ pub async fn parse_async(args: Option<&[&str]>) -> CliResult<()> {
         if preflight.set_hash_kind {
             set_local_hash_kind_for_storage(storage).await?;
         }
+    } else if preflight.set_hash_kind {
+        set_hash_kind(HashKind::Sha1);
     }
     // Resolve global output flags into a single config before dispatching.
     let color = if args.no_color {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,7 +35,7 @@ Command Groups:
   Commit And Branching    commit, branch, switch, checkout, tag, merge, rebase, reset, cherry-pick, revert
   Remote And Cloud        remote, fetch, pull, push, open, cloud, publish
   AI And Automation       code, code-control, automation, usage, graph, sandbox, agent
-  Maintenance And Plumbing db, cat-file, rev-parse, rev-list, symbolic-ref, reflog, bisect
+  Maintenance And Plumbing db, cat-file, verify-pack, rev-parse, rev-list, symbolic-ref, reflog, bisect
 
 Help Topics:
   error-codes  Print the stable CLI error code table (`libra help error-codes`)
@@ -253,6 +253,10 @@ enum Commands {
     Describe(command::describe::DescribeArgs),
     #[command(about = "Provide content, type or size info for repository objects")]
     CatFile(command::cat_file::CatFileArgs),
+    #[command(about = "Compute Git-compatible object IDs")]
+    HashObject(command::hash_object::HashObjectArgs),
+    #[command(about = "Validate pack index files against pack archives")]
+    VerifyPack(command::verify_pack::VerifyPackArgs),
 
     #[command(about = "Record changes to the repository", alias = "ci")]
     Commit(command::commit::CommitArgs),
@@ -1033,6 +1037,9 @@ pub async fn parse_async(args: Option<&[&str]>) -> CliResult<()> {
         }
         Commands::Push(cmd_args) => command::push::execute_safe(cmd_args, &output).await?,
         Commands::CatFile(cmd_args) => command::cat_file::execute_safe(cmd_args, &output).await?,
+        Commands::VerifyPack(cmd_args) => {
+            command::verify_pack::execute_safe(cmd_args, &output).await?
+        }
         Commands::IndexPack(cmd_args) => command::index_pack::execute_safe(cmd_args, &output)?,
         Commands::Fetch(cmd_args) => command::fetch::execute_safe(cmd_args, &output).await?,
         Commands::Diff(cmd_args) => command::diff::execute_safe(cmd_args, &output).await?,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -744,6 +744,14 @@ impl CommandPreflight {
             set_hash_kind: false,
         }
     }
+
+    fn repo_hash_kind_without_schema_guard(storage: std::path::PathBuf) -> Self {
+        Self {
+            storage: Some(storage),
+            check_schema: false,
+            set_hash_kind: true,
+        }
+    }
 }
 
 fn command_preflight(command: &Commands) -> CliResult<CommandPreflight> {
@@ -754,7 +762,12 @@ fn command_preflight(command: &Commands) -> CliResult<CommandPreflight> {
         | Commands::CodeControl(_)
         | Commands::LsRemote(_)
         | Commands::Sandbox(_) => Ok(CommandPreflight::none()),
-        Commands::VerifyPack(_) => Ok(CommandPreflight::sha1_without_repo()),
+        Commands::VerifyPack(_) => match utils::util::try_get_storage_path(None) {
+            Ok(storage) => Ok(CommandPreflight::repo_hash_kind_without_schema_guard(
+                storage,
+            )),
+            Err(_) => Ok(CommandPreflight::sha1_without_repo()),
+        },
         #[cfg(unix)]
         Commands::Worktree(command::worktree::WorktreeArgs {
             command: command::worktree::WorktreeSubcommand::Umount { .. },

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -59,6 +59,7 @@ pub mod show_ref;
 pub mod symbolic_ref;
 pub mod tag;
 pub mod usage;
+pub mod verify_pack;
 #[cfg(all(unix, feature = "worktree-fuse"))]
 #[path = "worktree-fuse.rs"]
 pub mod worktree;

--- a/src/command/rebase.rs
+++ b/src/command/rebase.rs
@@ -2032,12 +2032,12 @@ mod tests {
         internal::object::tree::{Tree, TreeItem, TreeItemMode},
     };
 
+    #[cfg(unix)]
+    use super::path_to_index_key;
     use super::{
         RebaseError, ReplayErrorKind, classify_relative_to_base, collect_tree_items_and_paths,
         resolve_three_way, tree_item_name,
     };
-    #[cfg(unix)]
-    use super::path_to_index_key;
     use crate::utils::error::{CliError, StableErrorCode};
 
     #[test]

--- a/src/command/rebase.rs
+++ b/src/command/rebase.rs
@@ -2034,7 +2034,7 @@ mod tests {
 
     use super::{
         RebaseError, ReplayErrorKind, classify_relative_to_base, collect_tree_items_and_paths,
-        path_to_index_key, resolve_three_way, tree_item_name,
+        resolve_three_way, tree_item_name,
     };
     use crate::utils::error::{CliError, StableErrorCode};
 

--- a/src/command/rebase.rs
+++ b/src/command/rebase.rs
@@ -2036,6 +2036,8 @@ mod tests {
         RebaseError, ReplayErrorKind, classify_relative_to_base, collect_tree_items_and_paths,
         resolve_three_way, tree_item_name,
     };
+    #[cfg(unix)]
+    use super::path_to_index_key;
     use crate::utils::error::{CliError, StableErrorCode};
 
     #[test]

--- a/src/command/verify_pack.rs
+++ b/src/command/verify_pack.rs
@@ -12,6 +12,7 @@ use git_internal::{
     hash::{HashKind, ObjectHash, get_hash_kind},
     internal::{
         metadata::{EntryMeta, MetaAttached},
+        object::types::ObjectType,
         pack::{Pack, entry::Entry, pack_index::IndexEntry},
     },
     utils::HashAlgorithm,
@@ -67,6 +68,9 @@ struct VerifyPackOutput {
 #[derive(Debug, Clone, Serialize)]
 struct VerifyPackObjectOutput {
     oid: String,
+    object_type: String,
+    size: usize,
+    size_in_pack: u64,
     offset: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     crc32: Option<u32>,
@@ -90,7 +94,15 @@ struct ParsedIndexEntry {
 #[derive(Debug, Clone)]
 struct DecodedPack {
     pack_hash: ObjectHash,
-    entries: BTreeMap<ObjectHash, IndexEntry>,
+    pack_len: u64,
+    entries: BTreeMap<ObjectHash, DecodedPackEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct DecodedPackEntry {
+    index: IndexEntry,
+    object_type: ObjectType,
+    size: usize,
 }
 
 pub async fn execute(args: VerifyPackArgs) -> Result<(), String> {
@@ -127,15 +139,35 @@ fn verify_pack(args: &VerifyPackArgs) -> CliResult<VerifyPackOutput> {
         .map_err(|detail| verification_failed(&idx_file, &pack_file, detail))?;
 
     let objects = if args.verbose {
+        let size_in_pack_by_hash = pack_entry_sizes(&parsed, decoded.pack_len)?;
         parsed
             .entries
             .iter()
-            .map(|entry| VerifyPackObjectOutput {
-                oid: entry.hash.to_string(),
-                offset: entry.offset,
-                crc32: entry.crc32,
+            .map(|entry| {
+                let decoded_entry = decoded.entries.get(&entry.hash).ok_or_else(|| {
+                    CliError::fatal(format!(
+                        "decoded pack metadata for indexed object {} is missing",
+                        entry.hash
+                    ))
+                    .with_stable_code(StableErrorCode::InternalInvariant)
+                })?;
+                let size_in_pack = *size_in_pack_by_hash.get(&entry.hash).ok_or_else(|| {
+                    CliError::fatal(format!(
+                        "pack size metadata for indexed object {} is missing",
+                        entry.hash
+                    ))
+                    .with_stable_code(StableErrorCode::InternalInvariant)
+                })?;
+                Ok(VerifyPackObjectOutput {
+                    oid: entry.hash.to_string(),
+                    object_type: decoded_entry.object_type.to_string(),
+                    size: decoded_entry.size,
+                    size_in_pack,
+                    offset: entry.offset,
+                    crc32: entry.crc32,
+                })
             })
-            .collect()
+            .collect::<CliResult<Vec<_>>>()?
     } else {
         Vec::new()
     };
@@ -421,6 +453,17 @@ fn decode_pack(pack_file: &Path) -> CliResult<DecodedPack> {
         ))
         .with_stable_code(StableErrorCode::IoReadFailed)
     })?;
+    let pack_len = file
+        .metadata()
+        .map_err(|error| {
+            CliError::fatal(format!(
+                "could not inspect pack file '{}' metadata: {}",
+                pack_file.display(),
+                format_io_error(&error)
+            ))
+            .with_stable_code(StableErrorCode::IoReadFailed)
+        })?
+        .len();
     let mut reader = io::BufReader::new(file);
     let entries = Arc::new(Mutex::new(Vec::new()));
     let entries_clone = Arc::clone(&entries);
@@ -460,13 +503,50 @@ fn decode_pack(pack_file: &Path) -> CliResult<DecodedPack> {
             ))
             .with_stable_code(StableErrorCode::RepoCorrupt)
         })?;
-        decoded_entries.insert(index_entry.hash, index_entry);
+        decoded_entries.insert(
+            index_entry.hash,
+            DecodedPackEntry {
+                index: index_entry,
+                object_type: entry.inner.obj_type,
+                size: entry.inner.data.len(),
+            },
+        );
     }
 
     Ok(DecodedPack {
         pack_hash: pack.signature,
+        pack_len,
         entries: decoded_entries,
     })
+}
+
+fn pack_entry_sizes(index: &ParsedIndex, pack_len: u64) -> CliResult<BTreeMap<ObjectHash, u64>> {
+    let trailer_start = pack_len
+        .checked_sub(get_hash_kind().size() as u64)
+        .ok_or_else(|| {
+            CliError::fatal("pack file is shorter than its trailing checksum")
+                .with_stable_code(StableErrorCode::RepoCorrupt)
+        })?;
+
+    let mut by_offset = index.entries.iter().collect::<Vec<_>>();
+    by_offset.sort_by_key(|entry| entry.offset);
+
+    let mut sizes = BTreeMap::new();
+    for (idx, entry) in by_offset.iter().enumerate() {
+        let next_offset = by_offset
+            .get(idx + 1)
+            .map(|next| next.offset)
+            .unwrap_or(trailer_start);
+        let size_in_pack = next_offset.checked_sub(entry.offset).ok_or_else(|| {
+            CliError::fatal(format!(
+                "pack entry offsets are not monotonically increasing near {}",
+                entry.hash
+            ))
+            .with_stable_code(StableErrorCode::RepoCorrupt)
+        })?;
+        sizes.insert(entry.hash, size_in_pack);
+    }
+    Ok(sizes)
 }
 
 fn take_mutex<T>(arc: Arc<Mutex<T>>, label: &str) -> Result<T, String> {
@@ -500,18 +580,18 @@ fn validate_index_against_pack(index: &ParsedIndex, pack: &DecodedPack) -> Resul
                 entry.hash
             ));
         };
-        if entry.offset != pack_entry.offset {
+        if entry.offset != pack_entry.index.offset {
             return Err(format!(
                 "offset mismatch for {}: index has {}, pack has {}",
-                entry.hash, entry.offset, pack_entry.offset
+                entry.hash, entry.offset, pack_entry.index.offset
             ));
         }
         if let Some(crc32) = entry.crc32
-            && crc32 != pack_entry.crc32
+            && crc32 != pack_entry.index.crc32
         {
             return Err(format!(
                 "crc32 mismatch for {}: index has {crc32:#010x}, pack has {:#010x}",
-                entry.hash, pack_entry.crc32
+                entry.hash, pack_entry.index.crc32
             ));
         }
     }
@@ -533,10 +613,10 @@ fn render_verify_pack_output(
 
     if verbose {
         for object in &result.objects {
-            match object.crc32 {
-                Some(crc32) => println!("{} {} {crc32:#010x}", object.oid, object.offset),
-                None => println!("{} {}", object.oid, object.offset),
-            }
+            println!(
+                "{} {} {} {} {}",
+                object.oid, object.object_type, object.size, object.size_in_pack, object.offset
+            );
         }
     }
     println!("{}: ok", result.idx_file);

--- a/src/command/verify_pack.rs
+++ b/src/command/verify_pack.rs
@@ -9,7 +9,7 @@ use std::{
 
 use clap::Parser;
 use git_internal::{
-    hash::{HashKind, ObjectHash, get_hash_kind},
+    hash::{HashKind, ObjectHash, get_hash_kind, set_hash_kind},
     internal::{
         metadata::{EntryMeta, MetaAttached},
         object::types::ObjectType,
@@ -133,6 +133,11 @@ fn verify_pack(args: &VerifyPackArgs) -> CliResult<VerifyPackOutput> {
         .unwrap_or_else(|| idx_file.with_extension("pack"));
 
     let idx_bytes = read_file(&idx_file, "pack index")?;
+    if let Some(hash_kind) =
+        infer_idx_v2_hash_kind(&idx_bytes).map_err(|detail| invalid_index(&idx_file, detail))?
+    {
+        set_hash_kind(hash_kind);
+    }
     let parsed = parse_index(&idx_bytes).map_err(|detail| invalid_index(&idx_file, detail))?;
     let decoded = decode_pack(&pack_file)?;
     validate_index_against_pack(&parsed, &decoded)
@@ -190,6 +195,89 @@ fn parse_index(bytes: &[u8]) -> Result<ParsedIndex, String> {
     } else {
         parse_idx_v1(bytes)
     }
+}
+
+fn infer_idx_v2_hash_kind(bytes: &[u8]) -> Result<Option<HashKind>, String> {
+    if !bytes.starts_with(&IDX_MAGIC) {
+        return Ok(None);
+    }
+
+    let version = u32::from_be_bytes(
+        bytes
+            .get(4..8)
+            .ok_or_else(|| "truncated v2 version".to_string())?
+            .try_into()
+            .map_err(|_| "truncated v2 version".to_string())?,
+    );
+    if version != 2 {
+        return Ok(None);
+    }
+
+    let fanout = parse_fanout(bytes, 8)?;
+    validate_fanout_monotonic(&fanout)?;
+    let object_count = fanout[255] as usize;
+    let mut candidates = [HashKind::Sha1, HashKind::Sha256]
+        .into_iter()
+        .filter(|kind| idx_v2_layout_matches_hash_kind(bytes, object_count, *kind))
+        .collect::<Vec<_>>();
+
+    match candidates.len() {
+        0 => Err("pack index v2 layout does not match sha1 or sha256".to_string()),
+        1 => Ok(candidates.pop()),
+        _ => {
+            let current = get_hash_kind();
+            if candidates.contains(&current) {
+                Ok(Some(current))
+            } else {
+                Ok(candidates.into_iter().next())
+            }
+        }
+    }
+}
+
+fn idx_v2_layout_matches_hash_kind(bytes: &[u8], object_count: usize, kind: HashKind) -> bool {
+    let hash_len = kind.size();
+    let Some(mut cursor) = (8 + FANOUT_LEN).checked_add(object_count.saturating_mul(hash_len))
+    else {
+        return false;
+    };
+    if cursor > bytes.len() {
+        return false;
+    }
+
+    let Some(crc_end) = cursor.checked_add(object_count.saturating_mul(4)) else {
+        return false;
+    };
+    if crc_end > bytes.len() {
+        return false;
+    }
+    cursor = crc_end;
+
+    let Some(offsets_end) = cursor.checked_add(object_count.saturating_mul(4)) else {
+        return false;
+    };
+    if offsets_end > bytes.len() {
+        return false;
+    }
+    let offset_table = &bytes[cursor..offsets_end];
+    cursor = offsets_end;
+
+    let large_count = offset_table
+        .chunks_exact(4)
+        .filter(|raw| {
+            let offset = u32::from_be_bytes([raw[0], raw[1], raw[2], raw[3]]);
+            offset & 0x8000_0000 != 0
+        })
+        .count();
+    let Some(trailer_start) = cursor.checked_add(large_count.saturating_mul(8)) else {
+        return false;
+    };
+    if trailer_start > bytes.len() {
+        return false;
+    }
+
+    let remaining = bytes.len() - trailer_start;
+    remaining == hash_len * 2 || remaining == hash_len + 20
 }
 
 fn parse_idx_v1(bytes: &[u8]) -> Result<ParsedIndex, String> {
@@ -476,8 +564,15 @@ fn decode_pack(pack_file: &Path) -> CliResult<DecodedPack> {
     pack.decode(
         &mut reader,
         move |entry: MetaAttached<Entry, EntryMeta>| {
+            let decoded_entry = IndexEntry::try_from(&entry)
+                .map(|index| DecodedPackEntry {
+                    index,
+                    object_type: entry.inner.obj_type,
+                    size: entry.inner.data.len(),
+                })
+                .map_err(|error| error.to_string());
             if let Ok(mut guard) = entries_clone.lock() {
-                guard.push(entry);
+                guard.push(decoded_entry);
             }
         },
         None::<fn(ObjectHash)>,
@@ -496,21 +591,14 @@ fn decode_pack(pack_file: &Path) -> CliResult<DecodedPack> {
             .with_stable_code(StableErrorCode::InternalInvariant)
     })?;
     for entry in entries {
-        let index_entry = IndexEntry::try_from(&entry).map_err(|error| {
+        let decoded_entry = entry.map_err(|error| {
             CliError::fatal(format!(
                 "failed to derive index metadata from pack '{}': {error}",
                 pack_file.display()
             ))
             .with_stable_code(StableErrorCode::RepoCorrupt)
         })?;
-        decoded_entries.insert(
-            index_entry.hash,
-            DecodedPackEntry {
-                index: index_entry,
-                object_type: entry.inner.obj_type,
-                size: entry.inner.data.len(),
-            },
-        );
+        decoded_entries.insert(decoded_entry.index.hash, decoded_entry);
     }
 
     Ok(DecodedPack {

--- a/src/command/verify_pack.rs
+++ b/src/command/verify_pack.rs
@@ -1,0 +1,592 @@
+//! Implements `verify-pack` for validating `.idx` files against their pack.
+
+use std::{
+    collections::BTreeMap,
+    fs, io,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use clap::Parser;
+use git_internal::{
+    hash::{HashKind, ObjectHash, get_hash_kind},
+    internal::{
+        metadata::{EntryMeta, MetaAttached},
+        pack::{Pack, entry::Entry, pack_index::IndexEntry},
+    },
+    utils::HashAlgorithm,
+};
+use serde::Serialize;
+use sha1::{Digest, Sha1};
+
+use crate::utils::{
+    error::{CliError, CliResult, StableErrorCode},
+    output::{OutputConfig, emit_json_data},
+};
+
+const IDX_MAGIC: [u8; 4] = [0xFF, 0x74, 0x4F, 0x63];
+const FANOUT_LEN: usize = 256 * 4;
+
+const VERIFY_PACK_EXAMPLES: &str = "\
+Examples:
+  libra verify-pack objects/pack/pack-abc123.idx
+  libra verify-pack --pack objects/pack/pack-abc123.pack objects/pack/pack-abc123.idx
+  libra verify-pack -v pack-abc123.idx
+  libra verify-pack pack-abc123.idx --json
+";
+
+#[derive(Parser, Debug)]
+#[command(after_help = VERIFY_PACK_EXAMPLES)]
+pub struct VerifyPackArgs {
+    /// Pack index file to verify
+    #[arg(value_name = "IDX_FILE")]
+    pub idx_file: PathBuf,
+
+    /// Pack file to verify against. Defaults to IDX_FILE with `.pack` extension.
+    #[arg(long, value_name = "PACK_FILE")]
+    pub pack: Option<PathBuf>,
+
+    /// Print every indexed object hash and offset
+    #[arg(short, long)]
+    pub verbose: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct VerifyPackOutput {
+    idx_file: String,
+    pack_file: String,
+    index_version: u8,
+    object_count: usize,
+    pack_hash: String,
+    index_hash: String,
+    verified: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    objects: Vec<VerifyPackObjectOutput>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct VerifyPackObjectOutput {
+    oid: String,
+    offset: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    crc32: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedIndex {
+    version: u8,
+    entries: Vec<ParsedIndexEntry>,
+    pack_hash: ObjectHash,
+    index_hash: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedIndexEntry {
+    hash: ObjectHash,
+    offset: u64,
+    crc32: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+struct DecodedPack {
+    pack_hash: ObjectHash,
+    entries: BTreeMap<ObjectHash, IndexEntry>,
+}
+
+pub async fn execute(args: VerifyPackArgs) -> Result<(), String> {
+    execute_safe(args, &OutputConfig::default())
+        .await
+        .map_err(|err| err.render())
+}
+
+/// # Side Effects
+///
+/// This command is read-only. It reads the requested `.idx` file and matching
+/// `.pack` file, decodes the pack, and reports whether the index is consistent.
+///
+/// # Errors
+///
+/// Returns structured CLI errors for unreadable files and repository-corruption
+/// errors for malformed indexes, malformed packs, or index/pack mismatches.
+pub async fn execute_safe(args: VerifyPackArgs, output: &OutputConfig) -> CliResult<()> {
+    let result = verify_pack(&args)?;
+    render_verify_pack_output(&result, args.verbose, output)
+}
+
+fn verify_pack(args: &VerifyPackArgs) -> CliResult<VerifyPackOutput> {
+    let idx_file = args.idx_file.clone();
+    let pack_file = args
+        .pack
+        .clone()
+        .unwrap_or_else(|| idx_file.with_extension("pack"));
+
+    let idx_bytes = read_file(&idx_file, "pack index")?;
+    let parsed = parse_index(&idx_bytes).map_err(|detail| invalid_index(&idx_file, detail))?;
+    let decoded = decode_pack(&pack_file)?;
+    validate_index_against_pack(&parsed, &decoded)
+        .map_err(|detail| verification_failed(&idx_file, &pack_file, detail))?;
+
+    let objects = if args.verbose {
+        parsed
+            .entries
+            .iter()
+            .map(|entry| VerifyPackObjectOutput {
+                oid: entry.hash.to_string(),
+                offset: entry.offset,
+                crc32: entry.crc32,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    Ok(VerifyPackOutput {
+        idx_file: path_string(&idx_file),
+        pack_file: path_string(&pack_file),
+        index_version: parsed.version,
+        object_count: parsed.entries.len(),
+        pack_hash: parsed.pack_hash.to_string(),
+        index_hash: bytes_to_hex(&parsed.index_hash),
+        verified: true,
+        objects,
+    })
+}
+
+fn parse_index(bytes: &[u8]) -> Result<ParsedIndex, String> {
+    if bytes.starts_with(&IDX_MAGIC) {
+        parse_idx_v2(bytes)
+    } else {
+        parse_idx_v1(bytes)
+    }
+}
+
+fn parse_idx_v1(bytes: &[u8]) -> Result<ParsedIndex, String> {
+    const HASH_LEN: usize = 20;
+    const ENTRY_LEN: usize = 4 + HASH_LEN;
+    const TRAILER_LEN: usize = HASH_LEN * 2;
+
+    if get_hash_kind() != HashKind::Sha1 {
+        return Err("pack index v1 only supports sha1 repositories".to_string());
+    }
+    if bytes.len() < FANOUT_LEN + TRAILER_LEN {
+        return Err("pack index v1 is too short".to_string());
+    }
+
+    let fanout = parse_fanout(bytes, 0)?;
+    validate_fanout_monotonic(&fanout)?;
+    let object_count = fanout[255] as usize;
+    let entries_start = FANOUT_LEN;
+    let entries_end = entries_start + object_count * ENTRY_LEN;
+    let expected_len = entries_end + TRAILER_LEN;
+    if bytes.len() != expected_len {
+        return Err(format!(
+            "pack index v1 length {} does not match fanout object count {}",
+            bytes.len(),
+            object_count
+        ));
+    }
+
+    let mut entries = Vec::with_capacity(object_count);
+    for i in 0..object_count {
+        let start = entries_start + i * ENTRY_LEN;
+        let offset = u32::from_be_bytes(
+            bytes[start..start + 4]
+                .try_into()
+                .map_err(|_| "truncated v1 offset".to_string())?,
+        ) as u64;
+        let hash = ObjectHash::from_bytes(&bytes[start + 4..start + ENTRY_LEN])
+            .map_err(|error| format!("invalid v1 object hash: {error}"))?;
+        entries.push(ParsedIndexEntry {
+            hash,
+            offset,
+            crc32: None,
+        });
+    }
+
+    validate_sorted_entries(&entries)?;
+    validate_fanout_matches_entries(&fanout, &entries)?;
+
+    let pack_hash = ObjectHash::from_bytes(&bytes[entries_end..entries_end + HASH_LEN])
+        .map_err(|error| format!("invalid v1 pack hash: {error}"))?;
+    let index_hash = bytes[entries_end + HASH_LEN..expected_len].to_vec();
+    let computed_hash: [u8; HASH_LEN] = Sha1::digest(&bytes[..expected_len - HASH_LEN]).into();
+    if index_hash != computed_hash {
+        return Err("pack index v1 checksum mismatch".to_string());
+    }
+
+    Ok(ParsedIndex {
+        version: 1,
+        entries,
+        pack_hash,
+        index_hash,
+    })
+}
+
+fn parse_idx_v2(bytes: &[u8]) -> Result<ParsedIndex, String> {
+    let hash_len = get_hash_kind().size();
+    if bytes.len() < 8 + FANOUT_LEN + hash_len * 2 {
+        return Err("pack index v2 is too short".to_string());
+    }
+    if bytes[0..4] != IDX_MAGIC {
+        return Err("pack index v2 magic mismatch".to_string());
+    }
+    let version = u32::from_be_bytes(
+        bytes[4..8]
+            .try_into()
+            .map_err(|_| "truncated v2 version".to_string())?,
+    );
+    if version != 2 {
+        return Err(format!("unsupported pack index version {version}"));
+    }
+
+    let fanout = parse_fanout(bytes, 8)?;
+    validate_fanout_monotonic(&fanout)?;
+    let object_count = fanout[255] as usize;
+    let mut cursor = 8 + FANOUT_LEN;
+
+    let names_end = cursor + object_count * hash_len;
+    if names_end > bytes.len() {
+        return Err("pack index v2 object names are truncated".to_string());
+    }
+    let names = &bytes[cursor..names_end];
+    cursor = names_end;
+
+    let crc_end = cursor + object_count * 4;
+    if crc_end > bytes.len() {
+        return Err("pack index v2 crc32 table is truncated".to_string());
+    }
+    let crc_table = &bytes[cursor..crc_end];
+    cursor = crc_end;
+
+    let offsets_end = cursor + object_count * 4;
+    if offsets_end > bytes.len() {
+        return Err("pack index v2 offset table is truncated".to_string());
+    }
+    let offset_table = &bytes[cursor..offsets_end];
+    cursor = offsets_end;
+
+    let mut large_count = 0usize;
+    for raw in offset_table.chunks_exact(4) {
+        let offset = u32::from_be_bytes(
+            raw.try_into()
+                .map_err(|_| "truncated v2 offset".to_string())?,
+        );
+        if offset & 0x8000_0000 != 0 {
+            large_count += 1;
+        }
+    }
+    let large_offsets_end = cursor + large_count * 8;
+    let trailer_start = large_offsets_end;
+    let expected_len = trailer_start + hash_len * 2;
+    if expected_len != bytes.len() {
+        return Err(
+            "pack index v2 length does not match fanout and large-offset tables".to_string(),
+        );
+    }
+
+    let mut large_offsets = Vec::with_capacity(large_count);
+    for chunk in bytes[cursor..large_offsets_end].chunks_exact(8) {
+        large_offsets.push(u64::from_be_bytes(
+            chunk
+                .try_into()
+                .map_err(|_| "truncated v2 large offset".to_string())?,
+        ));
+    }
+
+    let mut entries = Vec::with_capacity(object_count);
+    for i in 0..object_count {
+        let hash_start = i * hash_len;
+        let hash_end = hash_start + hash_len;
+        let hash = ObjectHash::from_bytes(&names[hash_start..hash_end])
+            .map_err(|error| format!("invalid v2 object hash: {error}"))?;
+
+        let crc_start = i * 4;
+        let crc32 = u32::from_be_bytes(
+            crc_table[crc_start..crc_start + 4]
+                .try_into()
+                .map_err(|_| "truncated v2 crc32".to_string())?,
+        );
+
+        let offset_start = i * 4;
+        let raw_offset = u32::from_be_bytes(
+            offset_table[offset_start..offset_start + 4]
+                .try_into()
+                .map_err(|_| "truncated v2 offset".to_string())?,
+        );
+        let offset = if raw_offset & 0x8000_0000 == 0 {
+            raw_offset as u64
+        } else {
+            let large_index = (raw_offset & 0x7FFF_FFFF) as usize;
+            *large_offsets
+                .get(large_index)
+                .ok_or_else(|| format!("v2 large-offset index {large_index} is out of range"))?
+        };
+
+        entries.push(ParsedIndexEntry {
+            hash,
+            offset,
+            crc32: Some(crc32),
+        });
+    }
+
+    validate_sorted_entries(&entries)?;
+    validate_fanout_matches_entries(&fanout, &entries)?;
+
+    let pack_hash = ObjectHash::from_bytes(&bytes[trailer_start..trailer_start + hash_len])
+        .map_err(|error| format!("invalid v2 pack hash: {error}"))?;
+    let index_hash = bytes[trailer_start + hash_len..expected_len].to_vec();
+
+    let computed_git_hash = hash_bytes(&bytes[..expected_len - hash_len]);
+    let computed_libra_hash = hash_bytes(&bytes[..trailer_start]);
+    if index_hash != computed_git_hash && index_hash != computed_libra_hash {
+        return Err("pack index v2 checksum mismatch".to_string());
+    }
+
+    Ok(ParsedIndex {
+        version: 2,
+        entries,
+        pack_hash,
+        index_hash,
+    })
+}
+
+fn parse_fanout(bytes: &[u8], offset: usize) -> Result<[u32; 256], String> {
+    if bytes.len() < offset + FANOUT_LEN {
+        return Err("pack index fanout table is truncated".to_string());
+    }
+
+    let mut fanout = [0u32; 256];
+    for (slot, chunk) in fanout
+        .iter_mut()
+        .zip(bytes[offset..offset + FANOUT_LEN].chunks_exact(4))
+    {
+        *slot = u32::from_be_bytes(
+            chunk
+                .try_into()
+                .map_err(|_| "truncated fanout entry".to_string())?,
+        );
+    }
+    Ok(fanout)
+}
+
+fn validate_fanout_monotonic(fanout: &[u32; 256]) -> Result<(), String> {
+    for pair in fanout.windows(2) {
+        if pair[0] > pair[1] {
+            return Err("pack index fanout table is not monotonic".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn validate_sorted_entries(entries: &[ParsedIndexEntry]) -> Result<(), String> {
+    for pair in entries.windows(2) {
+        if pair[0].hash > pair[1].hash {
+            return Err(format!(
+                "pack index object hashes are not sorted: {} > {}",
+                pair[0].hash, pair[1].hash
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_fanout_matches_entries(
+    fanout: &[u32; 256],
+    entries: &[ParsedIndexEntry],
+) -> Result<(), String> {
+    let mut computed = [0u32; 256];
+    for entry in entries {
+        computed[entry.hash.as_ref()[0] as usize] += 1;
+    }
+    for i in 1..computed.len() {
+        computed[i] += computed[i - 1];
+    }
+    if &computed != fanout {
+        return Err("pack index fanout table does not match object names".to_string());
+    }
+    Ok(())
+}
+
+fn decode_pack(pack_file: &Path) -> CliResult<DecodedPack> {
+    let file = fs::File::open(pack_file).map_err(|error| {
+        CliError::fatal(format!(
+            "could not open pack file '{}' for reading: {}",
+            pack_file.display(),
+            format_io_error(&error)
+        ))
+        .with_stable_code(StableErrorCode::IoReadFailed)
+    })?;
+    let mut reader = io::BufReader::new(file);
+    let entries = Arc::new(Mutex::new(Vec::new()));
+    let entries_clone = Arc::clone(&entries);
+    let tmp_path = pack_file
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+
+    let mut pack = Pack::new(Some(8), Some(1024 * 1024 * 1024), Some(tmp_path), true);
+    pack.decode(
+        &mut reader,
+        move |entry: MetaAttached<Entry, EntryMeta>| {
+            if let Ok(mut guard) = entries_clone.lock() {
+                guard.push(entry);
+            }
+        },
+        None::<fn(ObjectHash)>,
+    )
+    .map_err(|error| {
+        CliError::fatal(format!(
+            "failed to decode pack file '{}': {error}",
+            pack_file.display()
+        ))
+        .with_stable_code(StableErrorCode::RepoCorrupt)
+    })?;
+
+    let mut decoded_entries = BTreeMap::new();
+    let entries = take_mutex(entries, "verify-pack entries").map_err(|detail| {
+        CliError::fatal(format!("failed to collect decoded pack entries: {detail}"))
+            .with_stable_code(StableErrorCode::InternalInvariant)
+    })?;
+    for entry in entries {
+        let index_entry = IndexEntry::try_from(&entry).map_err(|error| {
+            CliError::fatal(format!(
+                "failed to derive index metadata from pack '{}': {error}",
+                pack_file.display()
+            ))
+            .with_stable_code(StableErrorCode::RepoCorrupt)
+        })?;
+        decoded_entries.insert(index_entry.hash, index_entry);
+    }
+
+    Ok(DecodedPack {
+        pack_hash: pack.signature,
+        entries: decoded_entries,
+    })
+}
+
+fn take_mutex<T>(arc: Arc<Mutex<T>>, label: &str) -> Result<T, String> {
+    let mutex =
+        Arc::try_unwrap(arc).map_err(|_| format!("{label} still has outstanding references"))?;
+    mutex
+        .into_inner()
+        .map_err(|_| format!("{label} mutex poisoned"))
+}
+
+fn validate_index_against_pack(index: &ParsedIndex, pack: &DecodedPack) -> Result<(), String> {
+    if index.pack_hash != pack.pack_hash {
+        return Err(format!(
+            "pack checksum mismatch: index has {}, pack has {}",
+            index.pack_hash, pack.pack_hash
+        ));
+    }
+
+    if index.entries.len() != pack.entries.len() {
+        return Err(format!(
+            "object count mismatch: index has {}, pack has {}",
+            index.entries.len(),
+            pack.entries.len()
+        ));
+    }
+
+    for entry in &index.entries {
+        let Some(pack_entry) = pack.entries.get(&entry.hash) else {
+            return Err(format!(
+                "indexed object {} is missing from pack",
+                entry.hash
+            ));
+        };
+        if entry.offset != pack_entry.offset {
+            return Err(format!(
+                "offset mismatch for {}: index has {}, pack has {}",
+                entry.hash, entry.offset, pack_entry.offset
+            ));
+        }
+        if let Some(crc32) = entry.crc32
+            && crc32 != pack_entry.crc32
+        {
+            return Err(format!(
+                "crc32 mismatch for {}: index has {crc32:#010x}, pack has {:#010x}",
+                entry.hash, pack_entry.crc32
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn render_verify_pack_output(
+    result: &VerifyPackOutput,
+    verbose: bool,
+    output: &OutputConfig,
+) -> CliResult<()> {
+    if output.is_json() {
+        return emit_json_data("verify-pack", result, output);
+    }
+    if output.quiet {
+        return Ok(());
+    }
+
+    if verbose {
+        for object in &result.objects {
+            match object.crc32 {
+                Some(crc32) => println!("{} {} {crc32:#010x}", object.oid, object.offset),
+                None => println!("{} {}", object.oid, object.offset),
+            }
+        }
+    }
+    println!("{}: ok", result.idx_file);
+    Ok(())
+}
+
+fn read_file(path: &Path, label: &str) -> CliResult<Vec<u8>> {
+    fs::read(path).map_err(|error| {
+        CliError::fatal(format!(
+            "could not open {label} '{}' for reading: {}",
+            path.display(),
+            format_io_error(&error)
+        ))
+        .with_stable_code(StableErrorCode::IoReadFailed)
+    })
+}
+
+fn invalid_index(path: &Path, detail: String) -> CliError {
+    CliError::fatal(format!("invalid pack index '{}': {detail}", path.display()))
+        .with_stable_code(StableErrorCode::RepoCorrupt)
+}
+
+fn verification_failed(idx_file: &Path, pack_file: &Path, detail: String) -> CliError {
+    CliError::fatal(format!(
+        "pack verification failed for '{}' against '{}': {detail}",
+        idx_file.display(),
+        pack_file.display()
+    ))
+    .with_stable_code(StableErrorCode::RepoCorrupt)
+}
+
+fn hash_bytes(bytes: &[u8]) -> Vec<u8> {
+    let mut hash = HashAlgorithm::new();
+    hash.update(bytes);
+    hash.finalize()
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn path_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn format_io_error(err: &io::Error) -> String {
+    match err.kind() {
+        io::ErrorKind::NotFound => "No such file or directory".to_string(),
+        io::ErrorKind::PermissionDenied => "Permission denied".to_string(),
+        _ => err.to_string(),
+    }
+}

--- a/src/command/verify_pack.rs
+++ b/src/command/verify_pack.rs
@@ -598,7 +598,13 @@ fn decode_pack(pack_file: &Path) -> CliResult<DecodedPack> {
             ))
             .with_stable_code(StableErrorCode::RepoCorrupt)
         })?;
-        decoded_entries.insert(decoded_entry.index.hash, decoded_entry);
+        insert_decoded_pack_entry(&mut decoded_entries, decoded_entry).map_err(|detail| {
+            CliError::fatal(format!(
+                "failed to decode pack file '{}': {detail}",
+                pack_file.display()
+            ))
+            .with_stable_code(StableErrorCode::RepoCorrupt)
+        })?;
     }
 
     Ok(DecodedPack {
@@ -606,6 +612,17 @@ fn decode_pack(pack_file: &Path) -> CliResult<DecodedPack> {
         pack_len,
         entries: decoded_entries,
     })
+}
+
+fn insert_decoded_pack_entry(
+    entries: &mut BTreeMap<ObjectHash, DecodedPackEntry>,
+    entry: DecodedPackEntry,
+) -> Result<(), String> {
+    let hash = entry.index.hash;
+    if entries.insert(hash, entry).is_some() {
+        return Err(format!("pack contains duplicate object ID {hash}"));
+    }
+    Ok(())
 }
 
 fn pack_entry_sizes(index: &ParsedIndex, pack_len: u64) -> CliResult<BTreeMap<ObjectHash, u64>> {
@@ -765,5 +782,37 @@ fn format_io_error(err: &io::Error) -> String {
         io::ErrorKind::NotFound => "No such file or directory".to_string(),
         io::ErrorKind::PermissionDenied => "Permission denied".to_string(),
         _ => err.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use git_internal::hash::{HashKind, set_hash_kind_for_test};
+
+    use super::*;
+
+    fn decoded_entry(hash: ObjectHash) -> DecodedPackEntry {
+        DecodedPackEntry {
+            index: IndexEntry {
+                hash,
+                crc32: 0,
+                offset: 12,
+            },
+            object_type: ObjectType::Blob,
+            size: 5,
+        }
+    }
+
+    #[test]
+    fn insert_decoded_pack_entry_rejects_duplicate_hashes() {
+        let _hash_guard = set_hash_kind_for_test(HashKind::Sha1);
+        let hash = ObjectHash::new(b"duplicate");
+        let mut entries = BTreeMap::new();
+
+        insert_decoded_pack_entry(&mut entries, decoded_entry(hash)).expect("first insert");
+        let err = insert_decoded_pack_entry(&mut entries, decoded_entry(hash))
+            .expect_err("duplicate hash should fail");
+
+        assert!(err.contains("duplicate object ID"));
     }
 }

--- a/src/command/verify_pack.rs
+++ b/src/command/verify_pack.rs
@@ -277,12 +277,13 @@ fn parse_idx_v2(bytes: &[u8]) -> Result<ParsedIndex, String> {
     }
     let large_offsets_end = cursor + large_count * 8;
     let trailer_start = large_offsets_end;
-    let expected_len = trailer_start + hash_len * 2;
-    if expected_len != bytes.len() {
+    let remaining = bytes.len().saturating_sub(trailer_start);
+    if remaining != hash_len * 2 && remaining != hash_len + 20 {
         return Err(
             "pack index v2 length does not match fanout and large-offset tables".to_string(),
         );
     }
+    let index_hash_len = remaining - hash_len;
 
     let mut large_offsets = Vec::with_capacity(large_count);
     for chunk in bytes[cursor..large_offsets_end].chunks_exact(8) {
@@ -334,11 +335,15 @@ fn parse_idx_v2(bytes: &[u8]) -> Result<ParsedIndex, String> {
 
     let pack_hash = ObjectHash::from_bytes(&bytes[trailer_start..trailer_start + hash_len])
         .map_err(|error| format!("invalid v2 pack hash: {error}"))?;
-    let index_hash = bytes[trailer_start + hash_len..expected_len].to_vec();
+    let index_hash = bytes[trailer_start + hash_len..].to_vec();
 
-    let computed_git_hash = hash_bytes(&bytes[..expected_len - hash_len]);
+    let computed_git_hash = hash_bytes(&bytes[..bytes.len() - index_hash_len]);
     let computed_libra_hash = hash_bytes(&bytes[..trailer_start]);
-    if index_hash != computed_git_hash && index_hash != computed_libra_hash {
+    let computed_legacy_sha1_libra_hash = sha1_bytes(&bytes[..trailer_start]);
+    if index_hash != computed_git_hash
+        && index_hash != computed_libra_hash
+        && index_hash != computed_legacy_sha1_libra_hash
+    {
         return Err("pack index v2 checksum mismatch".to_string());
     }
 
@@ -380,9 +385,9 @@ fn validate_fanout_monotonic(fanout: &[u32; 256]) -> Result<(), String> {
 
 fn validate_sorted_entries(entries: &[ParsedIndexEntry]) -> Result<(), String> {
     for pair in entries.windows(2) {
-        if pair[0].hash > pair[1].hash {
+        if pair[0].hash >= pair[1].hash {
             return Err(format!(
-                "pack index object hashes are not sorted: {} > {}",
+                "pack index object hashes are not strictly sorted: {} >= {}",
                 pair[0].hash, pair[1].hash
             ));
         }
@@ -567,6 +572,10 @@ fn hash_bytes(bytes: &[u8]) -> Vec<u8> {
     let mut hash = HashAlgorithm::new();
     hash.update(bytes);
     hash.finalize()
+}
+
+fn sha1_bytes(bytes: &[u8]) -> Vec<u8> {
+    Sha1::digest(bytes).to_vec()
 }
 
 fn bytes_to_hex(bytes: &[u8]) -> String {

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -323,6 +323,7 @@ mod switch_json_test;
 mod switch_test;
 mod symbolic_ref_test;
 mod tag_test;
+mod verify_pack_test;
 #[cfg(all(unix, feature = "worktree-fuse"))]
 mod worktree_fuse_test;
 mod worktree_test;

--- a/tests/command/verify_pack_test.rs
+++ b/tests/command/verify_pack_test.rs
@@ -227,10 +227,31 @@ fn verify_pack_accepts_generated_v2_index_with_verbose_objects() {
     assert_cli_success(&output, "verify-pack should accept generated v2 index");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let object_lines = stdout
+        .lines()
+        .filter(|line| !line.ends_with(": ok"))
+        .collect::<Vec<_>>();
     assert!(
-        stdout.lines().any(|line| line.contains("0x")),
-        "verbose output should include crc32 values: {stdout}"
+        !object_lines.is_empty(),
+        "expected verbose object rows: {stdout}"
     );
+    for line in object_lines {
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        assert_eq!(
+            fields.len(),
+            5,
+            "verbose rows should match Git's '<oid> <type> <size> <size-in-pack> <offset>' shape: {line}"
+        );
+        assert!(
+            matches!(fields[1], "blob" | "tree" | "commit" | "tag"),
+            "verbose type field should be a Git object type: {line}"
+        );
+        for field in &fields[2..] {
+            field
+                .parse::<u64>()
+                .unwrap_or_else(|_| panic!("verbose numeric field should parse: {line}"));
+        }
+    }
     assert!(
         stdout.trim_end().ends_with(": ok"),
         "verbose output should end with success line: {stdout}"

--- a/tests/command/verify_pack_test.rs
+++ b/tests/command/verify_pack_test.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use serial_test::serial;
+use sha1::{Digest, Sha1};
 
 use super::{
     assert_cli_success, init_repo_via_cli, parse_cli_error_stderr, parse_json_stdout,
@@ -52,6 +53,51 @@ fn build_index(repo: &Path, pack_path: &Path, version: &str) -> PathBuf {
     pack_path.with_extension("idx")
 }
 
+fn init_sha256_repo_via_cli(repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo dir");
+    let output = run_libra_command(&["init", "--object-format", "sha256"], repo);
+    assert_cli_success(&output, "failed to initialize sha256 repository");
+}
+
+fn corrupt_v1_index_with_duplicate_first_entry(idx_path: &Path) {
+    const FANOUT_LEN: usize = 256 * 4;
+    const HASH_LEN: usize = 20;
+    const ENTRY_LEN: usize = 4 + HASH_LEN;
+
+    let mut bytes = fs::read(idx_path).expect("read generated idx");
+    let object_count = u32::from_be_bytes(
+        bytes[FANOUT_LEN - 4..FANOUT_LEN]
+            .try_into()
+            .expect("fanout[255] is present"),
+    ) as usize;
+    assert!(
+        object_count >= 2,
+        "fixture index needs at least two objects"
+    );
+
+    let entries_start = FANOUT_LEN;
+    let first_entry = bytes[entries_start..entries_start + ENTRY_LEN].to_vec();
+    bytes[entries_start + ENTRY_LEN..entries_start + ENTRY_LEN * 2].copy_from_slice(&first_entry);
+
+    let mut fanout = [0u32; 256];
+    for idx in 0..object_count {
+        let hash_start = entries_start + idx * ENTRY_LEN + 4;
+        fanout[bytes[hash_start] as usize] += 1;
+    }
+    for idx in 1..fanout.len() {
+        fanout[idx] += fanout[idx - 1];
+    }
+    for (idx, count) in fanout.iter().enumerate() {
+        let start = idx * 4;
+        bytes[start..start + 4].copy_from_slice(&count.to_be_bytes());
+    }
+
+    let checksum_start = bytes.len() - HASH_LEN;
+    let checksum: [u8; HASH_LEN] = Sha1::digest(&bytes[..checksum_start]).into();
+    bytes[checksum_start..].copy_from_slice(&checksum);
+    fs::write(idx_path, bytes).expect("write duplicate idx");
+}
+
 #[test]
 #[serial]
 fn verify_pack_accepts_generated_v1_index() {
@@ -80,6 +126,39 @@ fn verify_pack_accepts_generated_v1_index() {
 
 #[test]
 #[serial]
+fn verify_pack_uses_repository_hash_kind_for_sha256_indexes() {
+    let repo = tempfile::tempdir().expect("create repo");
+    init_sha256_repo_via_cli(repo.path());
+    let (_pack_dir, pack_path) = copy_pack_to_temp("small-sha256");
+    let idx_path = build_index(repo.path(), &pack_path, "2");
+
+    let output = run_libra_command(
+        &[
+            "verify-pack",
+            idx_path.to_str().expect("idx path UTF-8"),
+            "--json",
+        ],
+        repo.path(),
+    );
+    assert_cli_success(
+        &output,
+        "verify-pack should use repository sha256 object format",
+    );
+
+    let json = parse_json_stdout(&output);
+    assert_eq!(json["command"], "verify-pack");
+    assert_eq!(json["data"]["index_version"], 2);
+    assert_eq!(
+        json["data"]["pack_hash"]
+            .as_str()
+            .expect("pack_hash should be string")
+            .len(),
+        64
+    );
+}
+
+#[test]
+#[serial]
 fn verify_pack_accepts_absolute_index_path_outside_repository() {
     let repo = tempfile::tempdir().expect("create repo");
     init_repo_via_cli(repo.path());
@@ -100,6 +179,32 @@ fn verify_pack_accepts_absolute_index_path_outside_repository() {
     assert!(
         stdout.contains(": ok"),
         "outside-repo verification should confirm success: {stdout}"
+    );
+}
+
+#[test]
+#[serial]
+fn verify_pack_rejects_duplicate_object_ids_even_with_valid_index_checksum() {
+    let repo = tempfile::tempdir().expect("create repo");
+    init_repo_via_cli(repo.path());
+    let (_pack_dir, pack_path) = copy_pack_to_temp("small-sha1");
+    let idx_path = build_index(repo.path(), &pack_path, "1");
+    corrupt_v1_index_with_duplicate_first_entry(&idx_path);
+
+    let output = run_libra_command(
+        &["verify-pack", idx_path.to_str().expect("idx path UTF-8")],
+        repo.path(),
+    );
+    assert!(
+        !output.status.success(),
+        "duplicate index object IDs should fail verification"
+    );
+
+    let (human, report) = parse_cli_error_stderr(&output.stderr);
+    assert_eq!(report.error_code, "LBR-REPO-002");
+    assert!(
+        human.contains("not strictly sorted"),
+        "error should identify duplicate or unsorted object IDs: {human}"
     );
 }
 

--- a/tests/command/verify_pack_test.rs
+++ b/tests/command/verify_pack_test.rs
@@ -1,0 +1,197 @@
+//! Tests for `verify-pack`, covering generated v1/v2 indexes, verbose output,
+//! JSON output, and corrupt/missing pack failures.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serial_test::serial;
+
+use super::{
+    assert_cli_success, init_repo_via_cli, parse_cli_error_stderr, parse_json_stdout,
+    run_libra_command,
+};
+
+fn packs_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/packs")
+}
+
+fn copy_pack_to_temp(prefix: &str) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let pack_src = fs::read_dir(packs_dir())
+        .expect("read packs dir")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(prefix) && name.ends_with(".pack"))
+        })
+        .unwrap_or_else(|| panic!("pack fixture with prefix {prefix:?} not found"));
+    let pack_dst = dir.path().join(
+        pack_src
+            .file_name()
+            .expect("pack fixture should have file name"),
+    );
+    fs::copy(&pack_src, &pack_dst).expect("copy pack fixture");
+    (dir, pack_dst)
+}
+
+fn build_index(repo: &Path, pack_path: &Path, version: &str) -> PathBuf {
+    let output = run_libra_command(
+        &[
+            "index-pack",
+            pack_path.to_str().expect("pack path should be UTF-8"),
+            "--index-version",
+            version,
+        ],
+        repo,
+    );
+    assert_cli_success(&output, "index-pack should build fixture index");
+    pack_path.with_extension("idx")
+}
+
+#[test]
+#[serial]
+fn verify_pack_accepts_generated_v1_index() {
+    let repo = tempfile::tempdir().expect("create repo");
+    init_repo_via_cli(repo.path());
+    let (_pack_dir, pack_path) = copy_pack_to_temp("small-sha1");
+    let idx_path = build_index(repo.path(), &pack_path, "1");
+
+    let output = run_libra_command(
+        &["verify-pack", idx_path.to_str().expect("idx path UTF-8")],
+        repo.path(),
+    );
+    assert_cli_success(&output, "verify-pack should accept generated v1 index");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(": ok"),
+        "human output should confirm success: {stdout}"
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "stderr should be clean: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+#[serial]
+fn verify_pack_accepts_generated_v2_index_with_verbose_objects() {
+    let repo = tempfile::tempdir().expect("create repo");
+    init_repo_via_cli(repo.path());
+    let (_pack_dir, pack_path) = copy_pack_to_temp("small-sha1");
+    let idx_path = build_index(repo.path(), &pack_path, "2");
+
+    let output = run_libra_command(
+        &[
+            "verify-pack",
+            "-v",
+            idx_path.to_str().expect("idx path UTF-8"),
+        ],
+        repo.path(),
+    );
+    assert_cli_success(&output, "verify-pack should accept generated v2 index");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.lines().any(|line| line.contains("0x")),
+        "verbose output should include crc32 values: {stdout}"
+    );
+    assert!(
+        stdout.trim_end().ends_with(": ok"),
+        "verbose output should end with success line: {stdout}"
+    );
+}
+
+#[test]
+#[serial]
+fn verify_pack_json_reports_counts_and_hashes() {
+    let repo = tempfile::tempdir().expect("create repo");
+    init_repo_via_cli(repo.path());
+    let (_pack_dir, pack_path) = copy_pack_to_temp("small-sha1");
+    let idx_path = build_index(repo.path(), &pack_path, "1");
+
+    let output = run_libra_command(
+        &[
+            "verify-pack",
+            idx_path.to_str().expect("idx path UTF-8"),
+            "--json",
+        ],
+        repo.path(),
+    );
+    assert_cli_success(&output, "verify-pack --json should succeed");
+
+    let json = parse_json_stdout(&output);
+    assert_eq!(json["command"], "verify-pack");
+    assert_eq!(json["data"]["verified"], true);
+    assert_eq!(json["data"]["index_version"], 1);
+    assert!(
+        json["data"]["object_count"].as_u64().unwrap_or_default() > 0,
+        "object_count should be positive: {json}"
+    );
+    assert!(
+        json["data"]["pack_hash"].as_str().unwrap_or_default().len() >= 40,
+        "pack_hash should be present: {json}"
+    );
+    assert!(
+        json["data"].get("objects").is_none(),
+        "non-verbose JSON should not include per-object payloads: {json}"
+    );
+}
+
+#[test]
+#[serial]
+fn verify_pack_rejects_corrupt_index_entry() {
+    let repo = tempfile::tempdir().expect("create repo");
+    init_repo_via_cli(repo.path());
+    let (_pack_dir, pack_path) = copy_pack_to_temp("small-sha1");
+    let idx_path = build_index(repo.path(), &pack_path, "1");
+
+    let mut bytes = fs::read(&idx_path).expect("read generated idx");
+    let first_hash_byte = 256 * 4 + 4;
+    bytes[first_hash_byte] ^= 0x80;
+    fs::write(&idx_path, bytes).expect("write corrupt idx");
+
+    let output = run_libra_command(
+        &["verify-pack", idx_path.to_str().expect("idx path UTF-8")],
+        repo.path(),
+    );
+    assert!(
+        !output.status.success(),
+        "corrupt index should fail verification"
+    );
+
+    let (human, report) = parse_cli_error_stderr(&output.stderr);
+    assert_eq!(report.error_code, "LBR-REPO-002");
+    assert!(
+        human.contains("invalid pack index") || human.contains("pack verification failed"),
+        "error should explain verification failure: {human}"
+    );
+}
+
+#[test]
+#[serial]
+fn verify_pack_reports_missing_pack_as_read_error() {
+    let repo = tempfile::tempdir().expect("create repo");
+    init_repo_via_cli(repo.path());
+    let (_pack_dir, pack_path) = copy_pack_to_temp("small-sha1");
+    let idx_path = build_index(repo.path(), &pack_path, "1");
+    fs::remove_file(&pack_path).expect("remove pack fixture");
+
+    let output = run_libra_command(
+        &["verify-pack", idx_path.to_str().expect("idx path UTF-8")],
+        repo.path(),
+    );
+    assert!(!output.status.success(), "missing pack should fail");
+
+    let (human, report) = parse_cli_error_stderr(&output.stderr);
+    assert_eq!(report.error_code, "LBR-IO-001");
+    assert!(
+        human.contains("could not open pack file"),
+        "error should identify missing pack: {human}"
+    );
+}

--- a/tests/command/verify_pack_test.rs
+++ b/tests/command/verify_pack_test.rs
@@ -184,6 +184,39 @@ fn verify_pack_accepts_absolute_index_path_outside_repository() {
 
 #[test]
 #[serial]
+fn verify_pack_accepts_sha256_index_path_outside_repository() {
+    let repo = tempfile::tempdir().expect("create repo");
+    init_sha256_repo_via_cli(repo.path());
+    let (_pack_dir, pack_path) = copy_pack_to_temp("small-sha256");
+    let idx_path = build_index(repo.path(), &pack_path, "2");
+    let outside = tempfile::tempdir().expect("create non-repo cwd");
+
+    let output = run_libra_command(
+        &[
+            "verify-pack",
+            idx_path.to_str().expect("idx path UTF-8"),
+            "--json",
+        ],
+        outside.path(),
+    );
+    assert_cli_success(
+        &output,
+        "verify-pack should infer sha256 index format outside a repo",
+    );
+
+    let json = parse_json_stdout(&output);
+    assert_eq!(json["data"]["index_version"], 2);
+    assert_eq!(
+        json["data"]["pack_hash"]
+            .as_str()
+            .expect("pack_hash should be string")
+            .len(),
+        64
+    );
+}
+
+#[test]
+#[serial]
 fn verify_pack_rejects_duplicate_object_ids_even_with_valid_index_checksum() {
     let repo = tempfile::tempdir().expect("create repo");
     init_repo_via_cli(repo.path());

--- a/tests/command/verify_pack_test.rs
+++ b/tests/command/verify_pack_test.rs
@@ -80,6 +80,31 @@ fn verify_pack_accepts_generated_v1_index() {
 
 #[test]
 #[serial]
+fn verify_pack_accepts_absolute_index_path_outside_repository() {
+    let repo = tempfile::tempdir().expect("create repo");
+    init_repo_via_cli(repo.path());
+    let (_pack_dir, pack_path) = copy_pack_to_temp("small-sha1");
+    let idx_path = build_index(repo.path(), &pack_path, "1");
+    let outside = tempfile::tempdir().expect("create non-repo cwd");
+
+    let output = run_libra_command(
+        &["verify-pack", idx_path.to_str().expect("idx path UTF-8")],
+        outside.path(),
+    );
+    assert_cli_success(
+        &output,
+        "verify-pack should accept absolute index paths outside a repo",
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(": ok"),
+        "outside-repo verification should confirm success: {stdout}"
+    );
+}
+
+#[test]
+#[serial]
 fn verify_pack_accepts_generated_v2_index_with_verbose_objects() {
     let repo = tempfile::tempdir().expect("create repo");
     init_repo_via_cli(repo.path());


### PR DESCRIPTION
  ## Summary
  - Add `libra verify-pack` for read-only `.idx` verification against matching `.pack` files
  - Validate index structure, fanout, sort order, index checksum, pack checksum, object count, object IDs, and offsets
  - Validate CRC32 values for v2 indexes
  - Support `--pack`, `-v/--verbose`, `--json`, and `--machine`
  - Document `verify-pack` and remove it from README pending commands

  ## Tests
  - cargo check
  - cargo +nightly fmt --all --check
  - cargo test --test command_test verify_pack_test -- --nocapture
  - cargo clippy --all-targets --all-features -- -D warnings