### PR TITLE
docs(readme): remove fsck from pending commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,6 @@ The following Git top-level commands are currently **not implemented** in Libra 
 
 - `gc` – garbage-collect unreachable objects and pack files
 - `prune` – remove loose objects that are no longer reachable
-- `fsck` – verify repository integrity
 - `maintenance` – periodic maintenance tasks
 - `pack-objects` / `unpack-objects` – pack and unpack object collections
 - `remote-show` – show detailed remote info


### PR DESCRIPTION
  ## Summary

  - Remove `fsck` from README's pending Git command list

  ## Rationale

  `libra fsck` is already implemented and wired into the CLI, with command docs and integration tests present. Keeping
  it in the pending list incorrectly suggests the command is unsupported.

  ## Tests

  - Not run; documentation-only change.