### PR TITLE
fix(hash-object): address cloud and test isolation followups

### DIFF
--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -67,6 +67,7 @@ pub(crate) struct CliErrorReport {
 fn base_libra_command(args: &[&str], cwd: &Path) -> Command {
     let home = cwd.join(".libra-test-home");
     let config_home = home.join(".config");
+    let global_db = home.join(".libra").join("config.db");
     fs::create_dir_all(&config_home).expect("failed to create isolated config directory");
 
     let mut command = Command::new(env!("CARGO_BIN_EXE_libra"));
@@ -78,6 +79,7 @@ fn base_libra_command(args: &[&str], cwd: &Path) -> Command {
         .env("HOME", &home)
         .env("USERPROFILE", &home)
         .env("XDG_CONFIG_HOME", &config_home)
+        .env("LIBRA_CONFIG_GLOBAL_DB", &global_db)
         .env("LANG", "C")
         .env("LC_ALL", "C")
         .env(LIBRA_TEST_ENV, "1");


### PR DESCRIPTION
  ## Summary

  - restore operation-specific cloud configuration errors for `sync` / `restore` while preserving structured
  `missing_keys`
  - allow read-only `hash-object` flows to read the repository hash kind without requiring the schema guard
  - isolate command integration tests from the real user-level Libra config database on Windows

  ## Details

  This follow-up fixes two behavior issues from the hash-object/cloud path:

  - `cloud` now keeps actionable operation-level error messages such as `missing cloud configuration for sync` /
  `restore`, while still exposing the missing configuration keys.
  - `hash-object` uses the repo hash kind lookup that skips the schema guard for read-only behavior.
  - command test helpers now set `LIBRA_CONFIG_GLOBAL_DB` after `env_clear()`, preventing Windows test subprocesses from
  resolving the real user DB at `C:\Users\guoziyu\.libra\config.db`.

  ## Tests

  - `cargo +nightly fmt --all`
  - `cargo check --lib`
  - `cargo test --test cloud_storage_backup_test` - 14 passed
  - `cargo test --lib hash_object` - 3 passed
  - `git diff --check`