### PR TITLE
fix(hash-object): address cloud and test isolation followups

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -214,6 +214,9 @@ jobs:
       - name: Run TUI automation scenarios
         env:
           LIBRA_ENABLE_TEST_PROVIDER: "1"
+          # These scenarios validate the loopback browser against the real
+          # embedded Next.js app, so the build.rs fallback stub is not valid here.
+          LIBRA_SKIP_WEB_BUILD: "0"
         run: |
           cargo test --features test-provider \
             --test code_ui_scenarios \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,7 @@ use clap::{
     error::{ContextKind, ContextValue, ErrorKind},
 };
 use git_internal::hash::{HashKind, set_hash_kind};
+use sea_orm::{ConnectionTrait, Statement};
 
 use crate::{
     command,
@@ -84,11 +85,94 @@ async fn set_local_hash_kind_for_storage(storage: &Path) -> CliResult<()> {
         })?;
     let object_format = ConfigKv::get_with_conn(&db_conn, "core.objectformat")
         .await
-        .ok()
-        .flatten()
+        .map_err(|e| {
+            CliError::fatal(format!(
+                "failed to read core.objectformat from repository database '{}': {}",
+                db_path.display(),
+                e
+            ))
+        })?
         .map(|e| e.value)
         .unwrap_or_else(|| "sha1".to_string());
 
+    set_hash_kind_from_object_format(object_format)
+}
+
+async fn set_local_hash_kind_for_storage_without_schema_guard(storage: &Path) -> CliResult<()> {
+    let db_path = storage.join(utils::util::DATABASE);
+    if !db_path.exists() {
+        return Err(CliError::fatal(format!(
+            "repository database not found at '{}'",
+            db_path.display()
+        )));
+    }
+
+    let db_conn = db::open_database_without_migrations(&db_path)
+        .await
+        .map_err(|e| {
+            CliError::fatal(format!(
+                "failed to open repository database '{}': {}",
+                db_path.display(),
+                e
+            ))
+        })?;
+    let object_format = read_schema_free_object_format(&db_conn, &db_path).await?;
+
+    set_hash_kind_from_object_format(object_format)
+}
+
+async fn read_schema_free_object_format(
+    db_conn: &sea_orm::DatabaseConnection,
+    db_path: &Path,
+) -> CliResult<String> {
+    let has_config_kv = db_conn
+        .query_one(Statement::from_sql_and_values(
+            db_conn.get_database_backend(),
+            "SELECT 1 FROM sqlite_master WHERE type = ? AND name = ? LIMIT 1",
+            ["table".into(), "config_kv".into()],
+        ))
+        .await
+        .map_err(|e| {
+            CliError::fatal(format!(
+                "failed to inspect repository database '{}': {}",
+                db_path.display(),
+                e
+            ))
+        })?
+        .is_some();
+
+    if !has_config_kv {
+        return Ok("sha1".to_string());
+    }
+
+    let row = db_conn
+        .query_one(Statement::from_sql_and_values(
+            db_conn.get_database_backend(),
+            "SELECT value FROM config_kv WHERE key = ? ORDER BY id DESC LIMIT 1",
+            ["core.objectformat".into()],
+        ))
+        .await
+        .map_err(|e| {
+            CliError::fatal(format!(
+                "failed to read core.objectformat from repository database '{}': {}",
+                db_path.display(),
+                e
+            ))
+        })?;
+
+    match row {
+        Some(row) => row.try_get_by_index(0).map_err(|e| {
+            CliError::fatal(format!(
+                "failed to decode core.objectformat from repository database '{}': {}",
+                db_path.display(),
+                e
+            ))
+        }),
+        None => Ok("sha1".to_string()),
+    }
+}
+
+fn set_hash_kind_from_object_format(object_format: String) -> CliResult<()> {
     let hash_kind = match object_format.as_str() {
         "sha1" => HashKind::Sha1,
         "sha256" => HashKind::Sha256,
@@ -768,7 +852,9 @@ fn command_preflight(command: &Commands) -> CliResult<CommandPreflight> {
         | Commands::Sandbox(_) => Ok(CommandPreflight::none()),
         Commands::HashObject(args) if !args.write => {
             match utils::util::try_get_storage_path(None) {
-                Ok(storage) => Ok(CommandPreflight::repo(storage)),
+                Ok(storage) => Ok(CommandPreflight::repo_hash_kind_without_schema_guard(
+                    storage,
+                )),
                 Err(_) => Ok(CommandPreflight::sha1_without_repo()),
             }
         }
@@ -982,7 +1068,11 @@ pub async fn parse_async(args: Option<&[&str]>) -> CliResult<()> {
             check_database_schema_for_storage(storage).await?;
         }
         if preflight.set_hash_kind {
-            set_local_hash_kind_for_storage(storage).await?;
+            if preflight.check_schema {
+                set_local_hash_kind_for_storage(storage).await?;
+            } else {
+                set_local_hash_kind_for_storage_without_schema_guard(storage).await?;
+            }
         }
     } else if preflight.set_hash_kind {
         set_hash_kind(HashKind::Sha1);
@@ -1193,6 +1283,20 @@ mod tests {
         assert!(preflight.storage.is_none());
         assert!(!preflight.check_schema);
         assert!(!preflight.set_hash_kind);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[serial]
+    async fn hash_object_read_only_preflight_skips_schema_guard() {
+        let repo = tempfile::tempdir().expect("failed to create test repo");
+        test::setup_with_new_libra_in(repo.path()).await;
+        let _guard = test::ChangeDirGuard::new(repo.path());
+        let cli = Cli::try_parse_from(["libra", "hash-object", "hello.txt"]).unwrap();
+
+        let preflight = command_preflight(&cli.command).unwrap();
+        assert!(preflight.storage.is_some());
+        assert!(!preflight.check_schema);
+        assert!(preflight.set_hash_kind);
     }
 
     /// Scenario: clap's built-in Levenshtein matcher should suggest `init` for the

--- a/src/command/hash_object.rs
+++ b/src/command/hash_object.rs
@@ -91,8 +91,12 @@ pub async fn execute_safe(args: HashObjectArgs, output: &OutputConfig) -> CliRes
         );
     }
 
-    let result = hash_objects(&args)?;
-    render_hash_object_output(&result, output)
+    if output.is_json() {
+        let result = hash_objects(&args)?;
+        return render_hash_object_output(&result, output);
+    }
+
+    hash_objects_streaming(&args, output)
 }
 
 fn hash_objects(args: &HashObjectArgs) -> CliResult<HashObjectOutput> {
@@ -115,6 +119,28 @@ fn hash_objects(args: &HashObjectArgs) -> CliResult<HashObjectOutput> {
         write: args.write,
         objects,
     })
+}
+
+fn hash_objects_streaming(args: &HashObjectArgs, output: &OutputConfig) -> CliResult<()> {
+    if output.quiet {
+        return hash_objects(args).map(|_| ());
+    }
+
+    let stdout = io::stdout();
+    let mut writer = stdout.lock();
+
+    if args.stdin {
+        let entry = hash_one_source("-", read_stdin()?, args.write)?;
+        write_hash_line(&mut writer, &entry.oid)?;
+        return Ok(());
+    }
+
+    for path in &args.paths {
+        let entry = hash_one_source(path.display().to_string(), read_file(path)?, args.write)?;
+        write_hash_line(&mut writer, &entry.oid)?;
+    }
+
+    Ok(())
 }
 
 fn hash_one_source(

--- a/tests/command/hash_object_test.rs
+++ b/tests/command/hash_object_test.rs
@@ -130,6 +130,31 @@ async fn hash_object_write_persists_blob_for_cat_file() {
 }
 
 #[tokio::test]
+async fn hash_object_batch_prints_successes_before_later_failure() {
+    let repo = tempfile::tempdir().expect("create temp repo");
+    init_repo_via_cli(repo.path());
+    fs::write(repo.path().join("first.txt"), b"first").expect("write fixture");
+
+    let output = run_libra_command(&["hash-object", "first.txt", "missing.txt"], repo.path());
+
+    assert!(
+        !output.status.success(),
+        "missing trailing input should fail the command"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "fe4f02ad058b43f6ed467fdf65b935107529564b"
+    );
+
+    let (human, report) = parse_cli_error_stderr(&output.stderr);
+    assert!(
+        human.contains("failed to read 'missing.txt'"),
+        "human stderr should explain unreadable input: {human}"
+    );
+    assert_eq!(report.error_code, "LBR-IO-001");
+}
+
+#[tokio::test]
 async fn hash_object_json_reports_source_size_and_write_mode() {
     let repo = tempfile::tempdir().expect("create temp repo");
     init_repo_via_cli(repo.path());

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -67,6 +67,7 @@ pub(crate) struct CliErrorReport {
 fn base_libra_command(args: &[&str], cwd: &Path) -> Command {
     let home = cwd.join(".libra-test-home");
     let config_home = home.join(".config");
+    let global_db = home.join(".libra").join("config.db");
     fs::create_dir_all(&config_home).expect("failed to create isolated config directory");
 
     let mut command = Command::new(env!("CARGO_BIN_EXE_libra"));
@@ -78,6 +79,7 @@ fn base_libra_command(args: &[&str], cwd: &Path) -> Command {
         .env("HOME", &home)
         .env("USERPROFILE", &home)
         .env("XDG_CONFIG_HOME", &config_home)
+        .env("LIBRA_CONFIG_GLOBAL_DB", &global_db)
         .env("LANG", "C")
         .env("LC_ALL", "C")
         .env(LIBRA_TEST_ENV, "1");

--- a/tests/command/schema_upgrade_test.rs
+++ b/tests/command/schema_upgrade_test.rs
@@ -121,3 +121,51 @@ async fn normal_command_refuses_stale_schema_and_does_not_upgrade() {
         "normal command preflight must not recreate pending indexes"
     );
 }
+
+#[tokio::test]
+async fn hash_object_read_only_skips_stale_schema_guard() {
+    let repo = stale_repo_at_approved_permission().await;
+    std::fs::write(repo.path().join("hello.txt"), b"hello world\n").expect("write fixture");
+
+    let output = run_libra_command(&["hash-object", "hello.txt"], repo.path());
+    assert_cli_success(
+        &output,
+        "read-only hash-object should not require db upgrade",
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "3b18e512dba79e4c8300dd08aeb37f8e728b8dad"
+    );
+
+    let conn = connect_raw_repo_db(repo.path()).await;
+    assert_eq!(max_schema_version(&conn).await, Some(2026050601));
+    assert!(
+        !column_exists(&conn, "agent_usage_stats", "agent_name").await,
+        "read-only hash-object preflight must not apply pending migrations"
+    );
+}
+
+#[tokio::test]
+async fn hash_object_read_only_defaults_sha1_when_config_kv_is_missing() {
+    let repo = stale_repo_at_approved_permission().await;
+    std::fs::write(repo.path().join("hello.txt"), b"hello world\n").expect("write fixture");
+
+    let conn = connect_raw_repo_db(repo.path()).await;
+    conn.execute(Statement::from_string(
+        conn.get_database_backend(),
+        "DROP TABLE config_kv",
+    ))
+    .await
+    .expect("drop config_kv table");
+    conn.close().await.expect("close raw connection");
+
+    let output = run_libra_command(&["hash-object", "hello.txt"], repo.path());
+    assert_cli_success(
+        &output,
+        "read-only hash-object should not require config_kv schema",
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "3b18e512dba79e4c8300dd08aeb37f8e728b8dad"
+    );
+}


### PR DESCRIPTION
  ## Summary

  - restore operation-scoped missing cloud configuration errors for cloud sync/restore
  - let read-only hash-object read the repository hash kind without running the schema guard
  - isolate command integration tests from the real user-level Libra config DB on Windows

  ## Details

  `cloud` missing-env errors now surface operation-level messages such as `missing cloud configuration for sync` /
  `restore`, while preserving the structured `missing_keys` detail.

  Read-only `hash-object` now uses the repo hash kind preflight path that skips schema guard checks, avoiding
  unnecessary schema validation for a read-only command.

  The command test helper also sets `LIBRA_CONFIG_GLOBAL_DB` after `env_clear()`, preventing Windows subprocesses from
  resolving `C:\Users\guoziyu\.libra\config.db`.

  ## Tests

  - `cargo +nightly fmt --all --check`
  - `cargo check --lib`
  - `cargo test --lib hash_object` - 2 passed
  - `git diff --check`