### PR TITLE
fix(ci): stabilize sandbox and command tests

### DIFF
--- a/docs/sandbox-seccomp.md
+++ b/docs/sandbox-seccomp.md
@@ -22,18 +22,38 @@ Libra ships a recommended baseline policy at
 Compile it once for your architecture and export
 `LIBRA_SECCOMP_POLICY`:
 
-1. Install one of:
+1. Install a seccomp compiler:
    * [`seccompiler`](https://crates.io/crates/seccompiler) (Rust;
      used by Firecracker) — `cargo install seccompiler-bin`
    * `libseccomp-tools` (`apt install libseccomp-tools` or
      `dnf install libseccomp-devel`)
 
+   If you externally precompile the bundled JSON on `aarch64` or
+   `riscv64`, also install `jq` for the preprocessing step below.
+
 2. Compile the bundled JSON to a BPF binary:
    ```sh
+   policy_json="$(libra repo-root)/template/seccomp-default.json"
+   tmp_policy_json=
+
+   # The bundled template keeps x86-only raw I/O denies for x86_64.
+   # When precompiling externally on aarch64/riscv64, remove those names
+   # before seccompiler validates the JSON.
+   case "$(uname -m)" in
+     aarch64|riscv64)
+       tmp_policy_json="$(mktemp)"
+       jq '(.default.filter) |= map(select(.syscall != "iopl" and .syscall != "ioperm"))' \
+           "$policy_json" > "$tmp_policy_json"
+       policy_json="$tmp_policy_json"
+       ;;
+   esac
+
    # seccompiler — recommended for portability
    seccompiler-bin --target-arch "$(uname -m)" \
-       --input-file "$(libra repo-root)/template/seccomp-default.json" \
+       --input-file "$policy_json" \
        --output-file ~/.libra/seccomp.bpf
+
+   [ -z "$tmp_policy_json" ] || rm -f "$tmp_policy_json"
 
    # Or hand-pasted from this doc into ~/.libra/seccomp.json
    # if you cloned without the bundled template/ directory.
@@ -53,9 +73,8 @@ Compile it once for your architecture and export
 
 5. If you compile to the fallback location, no env var is required:
    ```sh
-   seccompiler-bin --target-arch "$(uname -m)" \
-       --input-file "$(libra repo-root)/template/seccomp-default.json" \
-       --output-file "$HOME/.libra/seccomp.bpf"
+   # Reuse the architecture-specific compile command from step 2 with:
+   # --output-file "$HOME/.libra/seccomp.bpf"
 
    LIBRA_LOG=info libra code --goal 'noop' --network deny
    # → fallback path is used automatically.
@@ -65,9 +84,10 @@ Compile it once for your architecture and export
 
 The bundled
 [`template/seccomp-default.json`](../template/seccomp-default.json)
-groups syscalls into six intent-labelled buckets:
+uses the `seccompiler` JSON schema with one `default` filter. Its
+denylist rules group syscalls into six intent-labelled buckets:
 
-- **Mount manipulation** (`mount` / `umount` / `pivot_root` /
+- **Mount manipulation** (`mount` / `umount2` / `pivot_root` /
   `move_mount` / etc.) — could remount `/proc` or escape the
   bwrap mount namespace.
 - **Kernel module + kexec** (`init_module`, `finit_module`,
@@ -76,8 +96,10 @@ groups syscalls into six intent-labelled buckets:
 - **Process tampering** (`ptrace`, `process_vm_writev`,
   `process_vm_readv`) — cross-process memory access bypass.
 - **Host control** (`reboot`, `setdomainname`, `sethostname`,
-  `syslog`, `iopl`, `ioperm`) — system-wide identity / power /
-  I/O port access.
+  `syslog`, plus x86_64-only `iopl` / `ioperm`) — system-wide
+  identity / power / kernel log / raw I/O-port access. Libra's
+  runtime compiler filters x86_64-only names out when materialising
+  the default policy for aarch64/riscv64.
 - **Sandbox-bypass primitives** (`setns`, `unshare`) — re-enter
   namespaces or create new ones for escape.
 - **Kernel-introspection surfaces** (`perf_event_open`, `bpf`,
@@ -92,13 +114,25 @@ need `clone3` / `io_uring_setup` on newer kernels).
 
 `seccompiler-bin --target-arch` must match the runner's `uname
 -m`. A policy compiled for `x86_64` will be rejected at load time
-on `aarch64` because the syscall numbers differ. If you need both
-architectures, compile two policies and pick at startup:
+on `aarch64` or `riscv64` because the syscall numbers differ. The
+bundled JSON keeps `iopl` / `ioperm` so x86_64 root/container runs deny
+raw I/O-port access; Libra's built-in compiler removes those
+x86_64-only rules before compiling the fallback policy for
+aarch64/riscv64.
+
+That normalization only happens in Libra's built-in fallback compiler.
+If you use `seccompiler-bin` yourself on aarch64 or riscv64, do not
+pass the raw bundled JSON directly. First generate an
+architecture-specific JSON file that removes the `iopl` / `ioperm`
+filter entries, as shown in the quick start. If you need precompiled
+policies for multiple architectures, compile one per target and pick at
+startup:
 
 ```sh
 case "$(uname -m)" in
   x86_64)  export LIBRA_SECCOMP_POLICY="$HOME/.libra/seccomp-x86_64.bpf" ;;
   aarch64) export LIBRA_SECCOMP_POLICY="$HOME/.libra/seccomp-aarch64.bpf" ;;
+  riscv64) export LIBRA_SECCOMP_POLICY="$HOME/.libra/seccomp-riscv64.bpf" ;;
 esac
 ```
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -96,7 +96,7 @@ pub fn load_object<T>(hash: &ObjectHash) -> Result<T, GitError>
 where
     T: ObjectTrait,
 {
-    let storage = util::objects_storage();
+    let storage = util::try_objects_storage().map_err(GitError::IOError)?;
     let data = storage.get(hash)?;
     T::from_bytes(&data.to_vec(), *hash)
 }

--- a/src/command/push.rs
+++ b/src/command/push.rs
@@ -478,6 +478,26 @@ fn validate_push_args(args: &PushArgs) -> Result<(), PushError> {
     Ok(())
 }
 
+async fn validate_explicit_refspecs_before_discovery(args: &PushArgs) -> Result<(), PushError> {
+    if args.mirror {
+        return Ok(());
+    }
+
+    for refspec in &args.refspecs {
+        match parse_refspec(refspec)? {
+            ParsedRefspec::Update { src, dst } => {
+                let local_ref = resolve_local_ref(&src).await?;
+                normalize_destination_ref(&dst, local_ref.kind)?;
+            }
+            ParsedRefspec::Delete { dst } => {
+                normalize_delete_ref(&dst)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Pure execution
 // ---------------------------------------------------------------------------
@@ -518,6 +538,8 @@ pub async fn run_push(args: PushArgs, output: &OutputConfig) -> Result<PushOutpu
     if is_local_file_remote(&repo_url) {
         return Err(PushError::UnsupportedLocalFileRemote);
     }
+
+    validate_explicit_refspecs_before_discovery(&args).await?;
 
     // Determine transport: SSH or HTTPS
     let is_ssh = is_ssh_spec(&repo_url);

--- a/src/command/worktree-fuse.rs
+++ b/src/command/worktree-fuse.rs
@@ -4,11 +4,14 @@
 //! worktree management remains in `command::worktree`. Worktree-fuse command tests
 //! cover argument parsing and unsupported-platform behavior.
 
+#[cfg(target_os = "macos")]
+use std::env;
+#[cfg(target_os = "macos")]
+use std::process::{Command, Stdio};
 use std::{
     collections::HashMap,
-    env, fs, io,
+    fs, io,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
     sync::{Mutex, OnceLock},
     time::{Duration, Instant},
 };
@@ -361,10 +364,12 @@ fn fuse_data_root() -> PathBuf {
     util::storage_path().join("worktrees-fuse")
 }
 
+#[cfg(target_os = "macos")]
 struct DirGuard {
     old_dir: PathBuf,
 }
 
+#[cfg(target_os = "macos")]
 impl DirGuard {
     fn change_to(new_dir: &Path) -> io::Result<Self> {
         let old_dir = env::current_dir()?;
@@ -373,6 +378,7 @@ impl DirGuard {
     }
 }
 
+#[cfg(target_os = "macos")]
 impl Drop for DirGuard {
     fn drop(&mut self) {
         let _ = env::set_current_dir(&self.old_dir);
@@ -685,6 +691,7 @@ async fn add_fuse_worktree(
     let id = Uuid::new_v4().simple().to_string();
     let data_dir = fuse_data_root().join(id);
     let upper_dir = data_dir.join("upper");
+    #[cfg(target_os = "macos")]
     let lower_dir = data_dir.join("lower");
     fs::create_dir_all(&upper_dir)?;
 

--- a/src/internal/ai/orchestrator/executor.rs
+++ b/src/internal/ai/orchestrator/executor.rs
@@ -4550,10 +4550,7 @@ mod tests {
                             name: "submit_task_complete".to_string(),
                             arguments: serde_json::json!({
                                 "result": "pass",
-                                "summary": "implementation done",
-                                "evidence": [
-                                    {"command": "cargo test", "exit_code": 0}
-                                ]
+                                "summary": "implementation done"
                             }),
                         },
                     })],

--- a/src/internal/ai/sandbox/mod.rs
+++ b/src/internal/ai/sandbox/mod.rs
@@ -1803,13 +1803,17 @@ fn locate_bwrap_binary_for_prefer_strict() -> Option<PathBuf> {
         return None;
     }
 
-    let path_env = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path_env) {
-        let candidate = dir.join("bwrap");
-        if is_executable_file(&candidate) {
-            return Some(candidate);
+    #[cfg(not(test))]
+    {
+        let path_env = std::env::var_os("PATH")?;
+        for dir in std::env::split_paths(&path_env) {
+            let candidate = dir.join("bwrap");
+            if is_executable_file(&candidate) {
+                return Some(candidate);
+            }
         }
     }
+
     None
 }
 
@@ -2480,18 +2484,31 @@ mod tests {
     #[cfg_attr(target_os = "linux", serial)]
     #[test]
     fn seccomp_policy_env_resolves_path_only_when_non_empty() {
-        // SAFETY: test-only env mutation.
         let prior = std::env::var_os(SANDBOX_SECCOMP_POLICY_ENV);
-        let _policy = match prior {
-            Some(value) => Some(ScopedEnvVar::set(SANDBOX_SECCOMP_POLICY_ENV, value)),
-            None => {
-                // SAFETY: test-only env cleanup before running the assertion.
+
+        struct EnvRestore {
+            key: &'static str,
+            value: Option<std::ffi::OsString>,
+        }
+
+        impl Drop for EnvRestore {
+            fn drop(&mut self) {
                 unsafe {
-                    std::env::remove_var(SANDBOX_SECCOMP_POLICY_ENV);
+                    if let Some(value) = &self.value {
+                        std::env::set_var(self.key, value);
+                    } else {
+                        std::env::remove_var(self.key);
+                    }
                 }
-                None
             }
+        }
+
+        let _restore = EnvRestore {
+            key: SANDBOX_SECCOMP_POLICY_ENV,
+            value: prior,
         };
+
+        // SAFETY: test-only env mutation; restored by `_restore`.
         unsafe {
             std::env::remove_var(SANDBOX_SECCOMP_POLICY_ENV);
         }

--- a/src/internal/ai/sandbox/runtime.rs
+++ b/src/internal/ai/sandbox/runtime.rs
@@ -580,8 +580,8 @@ impl SandboxManager {
             });
         }
 
-        let (command, arg0, effective_sandbox) = match sandbox {
-            SandboxType::None => (command, None, SandboxType::None),
+        let (command, arg0, effective_sandbox, seccomp_policy_path_for_exec) = match sandbox {
+            SandboxType::None => (command, None, SandboxType::None, None),
             SandboxType::MacosSeatbelt => {
                 #[cfg(target_os = "macos")]
                 {
@@ -596,7 +596,7 @@ impl SandboxManager {
                     let mut full = Vec::with_capacity(1 + seatbelt_args.len());
                     full.push(MACOS_PATH_TO_SEATBELT_EXECUTABLE.to_string());
                     full.append(&mut seatbelt_args);
-                    (full, None, SandboxType::MacosSeatbelt)
+                    (full, None, SandboxType::MacosSeatbelt, None)
                 }
                 #[cfg(not(target_os = "macos"))]
                 {
@@ -621,6 +621,7 @@ impl SandboxManager {
                             full,
                             Some("libra-linux-sandbox".to_string()),
                             SandboxType::LinuxSeccomp,
+                            None,
                         )
                     } else if let Some(bwrap_path) = locate_bwrap_binary() {
                         // OC-Phase 7 P0 #2 + #3: built-in bwrap
@@ -637,6 +638,11 @@ impl SandboxManager {
                         // the doc contract.
                         let seccomp_fd = if seccomp_policy_path_for_transform.is_some() {
                             Some(SECCOMP_POLICY_FD)
+                        } else {
+                            None
+                        };
+                        let seccomp_policy_path_for_exec = if seccomp_fd.is_some() {
+                            seccomp_policy_path_for_transform.clone()
                         } else {
                             None
                         };
@@ -660,6 +666,7 @@ impl SandboxManager {
                             full,
                             Some("libra-linux-sandbox-bwrap".to_string()),
                             SandboxType::LinuxSeccomp,
+                            seccomp_policy_path_for_exec,
                         )
                     } else {
                         if enforcement.requires_effective_sandbox() {
@@ -670,7 +677,7 @@ impl SandboxManager {
                         tracing::warn!(
                             "linux sandbox executable not configured and bwrap not on PATH; running command without linux sandbox"
                         );
-                        (command, None, SandboxType::None)
+                        (command, None, SandboxType::None, None)
                     }
                 }
                 #[cfg(not(target_os = "linux"))]
@@ -704,7 +711,7 @@ impl SandboxManager {
                 SandboxType::MacosSeatbelt | SandboxType::LinuxSeccomp
             ),
             allowlist_proxy_services,
-            seccomp_policy_path: seccomp_policy_path_for_transform,
+            seccomp_policy_path: seccomp_policy_path_for_exec,
         })
     }
 }
@@ -873,8 +880,10 @@ pub fn create_bwrap_command_args_with_seccomp(
 /// `which`-style discovery is cheap (one stat per PATH entry,
 /// typically <10 lookups) and a stale cache would mislead a user
 /// that just installed bubblewrap mid-session. Tests that need a
-/// deterministic answer can set `LIBRA_BWRAP_BINARY` to bypass
-/// the PATH walk entirely.
+/// deterministic answer must set `LIBRA_BWRAP_BINARY` to bypass
+/// the PATH walk entirely; test builds do not scan the ambient
+/// PATH so CI images with an unusable host `bwrap` cannot change
+/// unrelated test behavior.
 ///
 /// Returns `None` on non-Linux platforms (the built-in bwrap
 /// path is Linux-only) or when no `bwrap` is reachable. Callers
@@ -889,7 +898,7 @@ fn locate_bwrap_binary() -> Option<PathBuf> {
         }
         return None;
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", not(test)))]
     {
         let path_env = std::env::var_os("PATH")?;
         for dir in std::env::split_paths(&path_env) {

--- a/src/internal/ai/sandbox/seccomp_compile.rs
+++ b/src/internal/ai/sandbox/seccomp_compile.rs
@@ -14,25 +14,32 @@
 //! 1. Takes the bundled JSON text (embedded at compile time via
 //!    `include_str!`) and the host's target arch (resolved at
 //!    runtime so cross-arch builds remain correct).
-//! 2. Calls `seccompiler::compile_from_json` to produce a
+//! 2. Normalises that JSON for the selected architecture, pruning
+//!    denylist entries for syscall names that do not exist there.
+//!    The bundled template keeps x86_64-only raw I/O denies
+//!    (`iopl` / `ioperm`) so root/container x86_64 runs still
+//!    block direct I/O-port access; aarch64 drops those entries
+//!    before handing the policy to seccompiler.
+//! 3. Calls `seccompiler::compile_from_json` to produce a
 //!    `BpfThreadMap` — a map from thread name (we only use the
 //!    `default` filter slot) to the assembled `BpfProgram`.
-//! 3. Serialises the program to the raw `Vec<u8>` shape `bwrap
+//! 4. Serialises the program to the raw `Vec<u8>` shape `bwrap
 //!    --seccomp <fd>` reads from the file descriptor we hand it
 //!    (each instruction is a 64-bit little-endian word — the
 //!    in-kernel `sock_filter` struct ABI).
 //!
-//! The output is intentionally byte-compatible with
-//! `seccompiler-bin --target-arch <arch> --input-file
-//! template/seccomp-default.json` so an operator who pre-compiled
-//! the policy with the standalone tool sees the same bytes the
-//! runtime would compile on its own.
+//! For x86_64, the output is intentionally byte-compatible with
+//! `seccompiler-bin --target-arch x86_64 --input-file
+//! template/seccomp-default.json`. For aarch64, Libra first removes
+//! x86_64-only syscall names from the bundled policy so the runtime
+//! can still materialise the default BPF without weakening x86_64.
 
 #![cfg(target_os = "linux")]
 
-use std::path::Path;
+use std::{io::Write, path::Path};
 
 use seccompiler::{BpfProgram, TargetArch, compile_from_json};
+use serde_json::Value;
 use thiserror::Error;
 
 /// Embedded JSON policy. Lives at `template/seccomp-default.json`
@@ -94,13 +101,18 @@ pub fn host_target_arch() -> Result<TargetArch, SeccompCompileError> {
 }
 
 /// Compile the bundled JSON policy into the raw BPF bytes
-/// `bwrap --seccomp <fd>` expects. The byte layout matches
-/// `seccompiler-bin --output bpf-bin --input-file
-/// template/seccomp-default.json` so a pre-compiled file and an
-/// on-the-fly compiled blob are interchangeable.
+/// `bwrap --seccomp <fd>` expects. The policy is normalised for
+/// the target architecture before seccompiler sees it.
 pub fn compile_bundled_seccomp_policy() -> Result<Vec<u8>, SeccompCompileError> {
     let arch = host_target_arch()?;
-    let mut filters = compile_from_json(BUNDLED_POLICY_JSON.as_bytes(), arch).map_err(|err| {
+    compile_bundled_seccomp_policy_for_arch(arch)
+}
+
+fn compile_bundled_seccomp_policy_for_arch(
+    arch: TargetArch,
+) -> Result<Vec<u8>, SeccompCompileError> {
+    let policy_json = policy_json_for_arch(arch)?;
+    let mut filters = compile_from_json(policy_json.as_bytes(), arch).map_err(|err| {
         SeccompCompileError::JsonInvalid {
             reason: err.to_string(),
         }
@@ -111,11 +123,53 @@ pub fn compile_bundled_seccomp_policy() -> Result<Vec<u8>, SeccompCompileError> 
     Ok(bpf_program_to_bytes(&program))
 }
 
+fn policy_json_for_arch(arch: TargetArch) -> Result<String, SeccompCompileError> {
+    let mut policy: Value = serde_json::from_str(BUNDLED_POLICY_JSON).map_err(|err| {
+        SeccompCompileError::JsonInvalid {
+            reason: err.to_string(),
+        }
+    })?;
+    prune_policy_for_arch(&mut policy, arch);
+    serde_json::to_string(&policy).map_err(|err| SeccompCompileError::JsonInvalid {
+        reason: err.to_string(),
+    })
+}
+
+fn prune_policy_for_arch(policy: &mut Value, arch: TargetArch) {
+    let Some(rules) = policy
+        .get_mut("default")
+        .and_then(|default| default.get_mut("filter"))
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+
+    rules.retain(|rule| {
+        let syscall = rule.get("syscall").and_then(Value::as_str);
+        match syscall {
+            Some(name) => bundled_policy_syscall_supported_on_arch(name, arch),
+            None => true,
+        }
+    });
+}
+
+fn bundled_policy_syscall_supported_on_arch(syscall: &str, arch: TargetArch) -> bool {
+    match arch {
+        TargetArch::x86_64 => true,
+        TargetArch::aarch64 | TargetArch::riscv64 => !matches!(syscall, "iopl" | "ioperm"),
+    }
+}
+
 /// Write the compiled policy to `path`, creating the parent
 /// directory if necessary. Used by the runtime's first-launch
 /// fallback path to materialise `~/.libra/seccomp.bpf` so the
 /// `--seccomp <fd>` wiring (v0.17.725) can pick it up on
 /// subsequent invocations.
+///
+/// The write is atomic from readers' perspective: a fresh process
+/// either sees no policy and compiles its own, or sees a complete
+/// policy after the temp-file rename. It must never observe the
+/// target path while BPF bytes are still being written.
 pub fn ensure_compiled_seccomp_policy_at(path: &Path) -> Result<(), std::io::Error> {
     if path.is_file() {
         return Ok(());
@@ -129,7 +183,22 @@ pub fn ensure_compiled_seccomp_policy_at(path: &Path) -> Result<(), std::io::Err
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(path, bytes)
+    write_policy_file_atomically(path, &bytes)
+}
+
+fn write_policy_file_atomically(path: &Path, bytes: &[u8]) -> Result<(), std::io::Error> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("seccomp.bpf");
+    let mut temp = tempfile::Builder::new()
+        .prefix(&format!(".{file_name}."))
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+    temp.write_all(bytes)?;
+    temp.as_file_mut().sync_all()?;
+    temp.persist(path).map(|_| ()).map_err(|err| err.error)
 }
 
 /// Serialise a `BpfProgram` (a `Vec<sock_filter>`) into the raw
@@ -182,6 +251,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn bundled_policy_compiles_for_supported_arches() {
+        for arch in [TargetArch::x86_64, TargetArch::aarch64] {
+            let bytes = compile_bundled_seccomp_policy_for_arch(arch).unwrap_or_else(|err| {
+                panic!("bundled seccomp JSON must compile for {arch:?}: {err}")
+            });
+            assert!(
+                bytes.len() >= 8,
+                "compiled BPF for {arch:?} must contain at least one sock_filter; got {} bytes",
+                bytes.len(),
+            );
+            assert_eq!(
+                bytes.len() % 8,
+                0,
+                "compiled BPF byte length for {arch:?} must be a multiple of 8; got {} bytes",
+                bytes.len(),
+            );
+        }
+    }
+
+    #[test]
+    fn policy_normalization_keeps_x86_raw_io_denies_and_filters_aarch64() {
+        let x86_policy =
+            policy_json_for_arch(TargetArch::x86_64).expect("x86 policy JSON normalizes");
+        assert!(
+            x86_policy.contains("\"syscall\":\"iopl\""),
+            "x86 policy must retain iopl raw I/O deny"
+        );
+        assert!(
+            x86_policy.contains("\"syscall\":\"ioperm\""),
+            "x86 policy must retain ioperm raw I/O deny"
+        );
+
+        let aarch64_policy =
+            policy_json_for_arch(TargetArch::aarch64).expect("aarch64 policy JSON normalizes");
+        assert!(
+            !aarch64_policy.contains("\"syscall\":\"iopl\""),
+            "aarch64 policy must drop x86-only iopl before seccompiler validation"
+        );
+        assert!(
+            !aarch64_policy.contains("\"syscall\":\"ioperm\""),
+            "aarch64 policy must drop x86-only ioperm before seccompiler validation"
+        );
+    }
+
     /// Scenario: `ensure_compiled_seccomp_policy_at` produces a
     /// file at the target path when none exists, and is a no-op
     /// when a file is already there (no re-compile, no overwrite).
@@ -203,6 +317,29 @@ mod tests {
         assert_ne!(
             bytes_before, bytes_after,
             "sentinel should differ from compiled BPF; sanity check failed",
+        );
+    }
+
+    #[test]
+    fn write_policy_file_atomically_writes_complete_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("nested").join("seccomp.bpf");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+
+        write_policy_file_atomically(&path, b"complete policy").expect("atomic write succeeds");
+
+        assert_eq!(
+            std::fs::read(&path).expect("read final policy"),
+            b"complete policy"
+        );
+        let leftovers: Vec<_> = std::fs::read_dir(path.parent().expect("parent"))
+            .expect("read parent")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name() != "seccomp.bpf")
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "atomic write should not leave temp files behind: {leftovers:?}"
         );
     }
 }

--- a/src/internal/ai/web/code_ui.rs
+++ b/src/internal/ai/web/code_ui.rs
@@ -1690,10 +1690,7 @@ mod tests {
     /// `(code, status)` set against the source-of-truth table.
     #[test]
     fn code_ui_error_code_listing_matches_authoritative_doc() {
-        let doc_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("docs/automation/local-tui-control.md");
-        let doc =
-            std::fs::read_to_string(&doc_path).expect("read docs/automation/local-tui-control.md");
+        let doc = include_str!("../../../../docs/automation/local-tui-control.md");
         let mut doc_pairs: Vec<(String, u16)> = Vec::new();
         for line in doc.lines() {
             // Markdown table rows look like `| \`CODE\` | 403 | gate description |`.

--- a/src/internal/config.rs
+++ b/src/internal/config.rs
@@ -1581,8 +1581,13 @@ async fn local_config_entry_for_target(
 ) -> Result<Option<ConfigKvEntry>> {
     match local_target {
         LocalIdentityTarget::CurrentRepo => {
-            let storage = crate::utils::util::try_get_storage_path(None)
-                .context("failed to resolve current repository storage")?;
+            let storage = match crate::utils::util::try_get_storage_path(None) {
+                Ok(storage) => storage,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(error) => {
+                    return Err(error).context("failed to resolve current repository storage");
+                }
+            };
             let db_path = storage.join(crate::utils::util::DATABASE);
             read_config_entry_from_db_path(&db_path, key).await
         }
@@ -1633,8 +1638,13 @@ async fn local_config_value_for_target(
 ) -> Result<Option<String>> {
     match local_target {
         LocalIdentityTarget::CurrentRepo => {
-            let storage = try_get_storage_path(None)
-                .context("failed to resolve current repository storage")?;
+            let storage = match try_get_storage_path(None) {
+                Ok(storage) => storage,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(error) => {
+                    return Err(error).context("failed to resolve current repository storage");
+                }
+            };
             let db_path = storage.join(DATABASE);
             read_config_value_from_db_path(&db_path, key).await
         }

--- a/src/internal/head.rs
+++ b/src/internal/head.rs
@@ -376,16 +376,24 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::utils::test::{self, ChangeDirGuard};
+    use crate::utils::test;
+
+    async fn db_for_repo(repo: &std::path::Path) -> sea_orm::DbConn {
+        let db_path = repo
+            .join(crate::utils::util::ROOT_DIR)
+            .join(crate::utils::util::DATABASE);
+        crate::internal::db::get_db_conn_instance_for_path(&db_path)
+            .await
+            .expect("test repository database should open")
+    }
 
     #[tokio::test]
     #[serial]
     async fn current_commit_result_with_conn_returns_corrupt_when_head_row_missing() {
         let repo = tempdir().unwrap();
         test::setup_with_new_libra_in(repo.path()).await;
-        let _guard = ChangeDirGuard::new(repo.path());
 
-        let db = get_db_conn_instance().await;
+        let db = db_for_repo(repo.path()).await;
         reference::Entity::delete_many()
             .filter(reference::Column::Kind.eq(reference::ConfigKind::Head))
             .filter(reference::Column::Remote.is_null())
@@ -408,9 +416,8 @@ mod tests {
     async fn current_commit_result_with_conn_returns_corrupt_for_invalid_detached_hash() {
         let repo = tempdir().unwrap();
         test::setup_with_new_libra_in(repo.path()).await;
-        let _guard = ChangeDirGuard::new(repo.path());
 
-        let db = get_db_conn_instance().await;
+        let db = db_for_repo(repo.path()).await;
         let head = reference::Entity::find()
             .filter(reference::Column::Kind.eq(reference::ConfigKind::Head))
             .filter(reference::Column::Remote.is_null())
@@ -446,9 +453,8 @@ mod tests {
     async fn remote_current_result_with_conn_returns_none_for_unknown_remote() {
         let repo = tempdir().unwrap();
         test::setup_with_new_libra_in(repo.path()).await;
-        let _guard = ChangeDirGuard::new(repo.path());
 
-        let db = get_db_conn_instance().await;
+        let db = db_for_repo(repo.path()).await;
         let result = Head::remote_current_result_with_conn(&db, "no-such-remote")
             .await
             .expect("unknown remote should not surface as error");
@@ -469,9 +475,8 @@ mod tests {
     async fn remote_current_result_with_conn_returns_corrupt_for_invalid_detached_hash() {
         let repo = tempdir().unwrap();
         test::setup_with_new_libra_in(repo.path()).await;
-        let _guard = ChangeDirGuard::new(repo.path());
 
-        let db = get_db_conn_instance().await;
+        let db = db_for_repo(repo.path()).await;
         let remote = "origin";
         let row = reference::ActiveModel {
             kind: Set(reference::ConfigKind::Head),
@@ -509,9 +514,8 @@ mod tests {
     async fn current_with_conn_panics_with_invariant_message_when_head_corrupt() {
         let repo = tempdir().unwrap();
         test::setup_with_new_libra_in(repo.path()).await;
-        let _guard = ChangeDirGuard::new(repo.path());
 
-        let db = get_db_conn_instance().await;
+        let db = db_for_repo(repo.path()).await;
         reference::Entity::delete_many()
             .filter(reference::Column::Kind.eq(reference::ConfigKind::Head))
             .filter(reference::Column::Remote.is_null())
@@ -535,9 +539,8 @@ mod tests {
     async fn remote_current_with_conn_panics_with_invariant_message_when_remote_head_corrupt() {
         let repo = tempdir().unwrap();
         test::setup_with_new_libra_in(repo.path()).await;
-        let _guard = ChangeDirGuard::new(repo.path());
 
-        let db = get_db_conn_instance().await;
+        let db = db_for_repo(repo.path()).await;
         let remote = "origin";
         let row = reference::ActiveModel {
             kind: Set(reference::ConfigKind::Head),

--- a/template/seccomp-default.json
+++ b/template/seccomp-default.json
@@ -1,59 +1,120 @@
 {
-  "_comment": [
-    "Recommended baseline seccomp BPF policy for `libra code` Linux sandbox.",
-    "",
-    "Compile with seccompiler:",
-    "  seccompiler-bin --target-arch \"$(uname -m)\" \\",
-    "      --input-file template/seccomp-default.json \\",
-    "      --output-file ~/.libra/seccomp.bpf",
-    "  export LIBRA_SECCOMP_POLICY=\"$HOME/.libra/seccomp.bpf\"",
-    "",
-    "See docs/sandbox-seccomp.md for the full how-to, precedence rules,",
-    "and architecture caveats (x86_64 vs aarch64 syscall numbers diverge).",
-    "",
-    "Policy intent (sandbox.md §7 G6): kill the worst sandbox-escape and",
-    "kernel-manipulation vectors; let everything else run so normal AI",
-    "agent workloads (cargo, pytest, npm, shell pipelines) remain",
-    "unaffected. Tune the syscalls list for your environment — adding",
-    "more denies tightens the sandbox but risks breaking legitimate",
-    "tools that rely on namespace / ptrace primitives (e.g. some",
-    "container build tools, debuggers, profilers).",
-    "",
-    "This file is JSON-with-comments only at the top level (the",
-    "`_comment` key is ignored by seccompiler's deserialiser); the",
-    "policy body below uses the strict seccompiler v0.4+ schema."
-  ],
-  "default_action": "allow",
-  "filter": [
-    {
-      "action": "kill_process",
-      "comment": "Mount manipulation — could remount /proc or escape the bwrap mount namespace.",
-      "syscalls": ["mount", "umount", "umount2", "pivot_root", "open_tree", "move_mount", "fsopen", "fsmount", "fsconfig", "fspick"]
-    },
-    {
-      "action": "kill_process",
-      "comment": "Kernel module + kexec — direct kernel-mode escalation.",
-      "syscalls": ["init_module", "finit_module", "delete_module", "kexec_load", "kexec_file_load"]
-    },
-    {
-      "action": "kill_process",
-      "comment": "Process tampering — ptrace ATTACH and cross-process memory access.",
-      "syscalls": ["ptrace", "process_vm_writev", "process_vm_readv"]
-    },
-    {
-      "action": "kill_process",
-      "comment": "Host control — system-wide identity / power / I/O port access.",
-      "syscalls": ["reboot", "setdomainname", "sethostname", "syslog", "iopl", "ioperm"]
-    },
-    {
-      "action": "kill_process",
-      "comment": "Sandbox-bypass primitives — re-enter namespaces or create new ones for escape.",
-      "syscalls": ["setns", "unshare"]
-    },
-    {
-      "action": "kill_process",
-      "comment": "Kernel-introspection surfaces — perf_event_open and BPF program load are common LPE rungs.",
-      "syscalls": ["perf_event_open", "bpf", "userfaultfd"]
-    }
-  ]
+  "default": {
+    "mismatch_action": "allow",
+    "match_action": "kill_process",
+    "filter": [
+      {
+        "syscall": "mount",
+        "comment": "Mount manipulation could remount /proc or escape the bwrap mount namespace."
+      },
+      {
+        "syscall": "umount2",
+        "comment": "Mount manipulation could remount /proc or escape the bwrap mount namespace."
+      },
+      {
+        "syscall": "pivot_root",
+        "comment": "Mount manipulation could remount /proc or escape the bwrap mount namespace."
+      },
+      {
+        "syscall": "open_tree",
+        "comment": "Mount manipulation could remount /proc or escape the bwrap mount namespace."
+      },
+      {
+        "syscall": "move_mount",
+        "comment": "Mount manipulation could remount /proc or escape the bwrap mount namespace."
+      },
+      {
+        "syscall": "fsopen",
+        "comment": "Mount manipulation could remount /proc or escape the bwrap mount namespace."
+      },
+      {
+        "syscall": "fsmount",
+        "comment": "Mount manipulation could remount /proc or escape the bwrap mount namespace."
+      },
+      {
+        "syscall": "fsconfig",
+        "comment": "Mount manipulation could remount /proc or escape the bwrap mount namespace."
+      },
+      {
+        "syscall": "fspick",
+        "comment": "Mount manipulation could remount /proc or escape the bwrap mount namespace."
+      },
+      {
+        "syscall": "init_module",
+        "comment": "Kernel module and kexec calls are direct kernel-mode escalation surfaces."
+      },
+      {
+        "syscall": "finit_module",
+        "comment": "Kernel module and kexec calls are direct kernel-mode escalation surfaces."
+      },
+      {
+        "syscall": "delete_module",
+        "comment": "Kernel module and kexec calls are direct kernel-mode escalation surfaces."
+      },
+      {
+        "syscall": "kexec_load",
+        "comment": "Kernel module and kexec calls are direct kernel-mode escalation surfaces."
+      },
+      {
+        "syscall": "kexec_file_load",
+        "comment": "Kernel module and kexec calls are direct kernel-mode escalation surfaces."
+      },
+      {
+        "syscall": "ptrace",
+        "comment": "Process tampering can inspect or modify another process."
+      },
+      {
+        "syscall": "process_vm_writev",
+        "comment": "Process tampering can inspect or modify another process."
+      },
+      {
+        "syscall": "process_vm_readv",
+        "comment": "Process tampering can inspect or modify another process."
+      },
+      {
+        "syscall": "reboot",
+        "comment": "Host control calls affect system-wide identity, power, or kernel logs."
+      },
+      {
+        "syscall": "setdomainname",
+        "comment": "Host control calls affect system-wide identity, power, or kernel logs."
+      },
+      {
+        "syscall": "sethostname",
+        "comment": "Host control calls affect system-wide identity, power, or kernel logs."
+      },
+      {
+        "syscall": "syslog",
+        "comment": "Host control calls affect system-wide identity, power, or kernel logs."
+      },
+      {
+        "syscall": "iopl",
+        "comment": "Raw I/O-port access can bypass device isolation on x86 hosts."
+      },
+      {
+        "syscall": "ioperm",
+        "comment": "Raw I/O-port access can bypass device isolation on x86 hosts."
+      },
+      {
+        "syscall": "setns",
+        "comment": "Namespace calls can re-enter namespaces or create new ones for escape."
+      },
+      {
+        "syscall": "unshare",
+        "comment": "Namespace calls can re-enter namespaces or create new ones for escape."
+      },
+      {
+        "syscall": "perf_event_open",
+        "comment": "Kernel-introspection surfaces are common local privilege escalation rungs."
+      },
+      {
+        "syscall": "bpf",
+        "comment": "Kernel-introspection surfaces are common local privilege escalation rungs."
+      },
+      {
+        "syscall": "userfaultfd",
+        "comment": "Kernel-introspection surfaces are common local privilege escalation rungs."
+      }
+    ]
+  }
 }

--- a/tests/agent_capture_migration_test.rs
+++ b/tests/agent_capture_migration_test.rs
@@ -123,17 +123,19 @@ async fn agent_capture_rollback_drops_tables_and_indexes_only() {
 
     // Rolling back to before agent_capture also rolls back every migration
     // sitting on top of it (parent_commit nullable, approved_permission,
-    // agent_usage_stats agent_name column, source_call_log). Rollback
-    // returns versions in reverse-application order — newest first — so the
-    // list reads from the most recent built-in migration down to
-    // agent_capture itself.
+    // agent_usage_stats agent_name column, source_call_log, and the
+    // source_call_log agent_run_id column). Rollback returns versions in
+    // reverse-application order — newest first — so the list reads from the
+    // most recent built-in migration down to agent_capture itself.
     let rolled_back = runner
         .rollback_to(&conn, 2026050302)
         .await
         .expect("rollback_to(2026050302)");
     assert_eq!(
         rolled_back,
-        vec![2026052301, 2026050801, 2026050601, 2026050501, 2026050303]
+        vec![
+            2026060201, 2026052301, 2026050801, 2026050601, 2026050501, 2026050303
+        ]
     );
 
     // agent_capture artifacts gone.

--- a/tests/command/cat_file_test.rs
+++ b/tests/command/cat_file_test.rs
@@ -12,14 +12,11 @@
 //! output (`tree <hash>`, tree entries `mode blob <hash>\t<name>`); these
 //! parsers must therefore stay in sync with the cat-file pretty-printer.
 
-use std::{
-    io::{Read, Write},
-    process::Command,
-};
+use std::io::{Read, Write};
 
 use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
 
-use super::{loose_object_path, parse_cli_error_stderr, parse_json_stdout};
+use super::{libra_command, loose_object_path, parse_cli_error_stderr, parse_json_stdout};
 
 /// Spawn `libra init` in a fresh tempdir and return the `TempDir` (kept
 /// alive by the caller for RAII cleanup).
@@ -27,8 +24,7 @@ fn init_temp_repo() -> tempfile::TempDir {
     let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["init"])
         .output()
         .expect("Failed to execute libra binary");
@@ -46,15 +42,13 @@ fn init_temp_repo() -> tempfile::TempDir {
 /// Configure `user.name` / `user.email` through the CLI so subsequent
 /// commits can be authored. Required before `create_commit()`.
 fn configure_user_identity(temp_path: &std::path::Path) {
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["config", "user.name", "Test User"])
         .output()
         .expect("Failed to configure user.name");
     assert!(output.status.success(), "Failed to configure user.name");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["config", "user.email", "test@example.com"])
         .output()
         .expect("Failed to configure user.email");
@@ -67,8 +61,7 @@ fn configure_user_identity(temp_path: &std::path::Path) {
 fn create_commit(temp_path: &std::path::Path, filename: &str, content: &str, message: &str) {
     std::fs::write(temp_path.join(filename), content).expect("Failed to create file");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["add", filename])
         .output()
         .expect("Failed to add file");
@@ -78,8 +71,7 @@ fn create_commit(temp_path: &std::path::Path, filename: &str, content: &str, mes
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["commit", "-m", message, "--no-verify"])
         .output()
         .expect("Failed to commit");
@@ -100,8 +92,7 @@ async fn test_cat_file_type_commit() {
     configure_user_identity(temp_path);
     create_commit(temp_path, "hello.txt", "hello world\n", "first commit");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-t", "HEAD"])
         .output()
         .expect("Failed to execute cat-file");
@@ -131,8 +122,7 @@ async fn test_cat_file_size_commit() {
     configure_user_identity(temp_path);
     create_commit(temp_path, "hello.txt", "hello world\n", "first commit");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-s", "HEAD"])
         .output()
         .expect("Failed to execute cat-file");
@@ -158,8 +148,7 @@ async fn test_cat_file_type_json_output() {
     configure_user_identity(temp_path);
     create_commit(temp_path, "hello.txt", "hello world\n", "first commit");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-t", "HEAD", "--json"])
         .output()
         .expect("Failed to execute cat-file");
@@ -189,8 +178,7 @@ async fn test_cat_file_pretty_commit() {
     configure_user_identity(temp_path);
     create_commit(temp_path, "hello.txt", "hello world\n", "first commit");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", "HEAD"])
         .output()
         .expect("Failed to execute cat-file");
@@ -237,8 +225,7 @@ async fn test_cat_file_pretty_tree() {
     create_commit(temp_path, "file.txt", "content\n", "add file");
 
     // Get the tree hash from the commit
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", "HEAD"])
         .output()
         .expect("Failed to execute cat-file");
@@ -253,8 +240,7 @@ async fn test_cat_file_pretty_tree() {
         .trim();
 
     // Now cat-file -p the tree
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", tree_hash])
         .output()
         .expect("Failed to execute cat-file on tree");
@@ -277,8 +263,7 @@ async fn test_cat_file_pretty_tree() {
     );
 
     // cat-file -t the tree should return "tree"
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-t", tree_hash])
         .output()
         .expect("Failed to execute cat-file -t on tree");
@@ -302,8 +287,7 @@ async fn test_cat_file_pretty_blob() {
     create_commit(temp_path, "readme.txt", "Hello, Libra!\n", "init readme");
 
     // Get tree hash, then blob hash from tree
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", "HEAD"])
         .output()
         .unwrap();
@@ -316,8 +300,7 @@ async fn test_cat_file_pretty_blob() {
         .unwrap()
         .trim();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", tree_hash])
         .output()
         .unwrap();
@@ -337,8 +320,7 @@ async fn test_cat_file_pretty_blob() {
         .unwrap();
 
     // cat-file -p the blob
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", blob_hash])
         .output()
         .unwrap();
@@ -351,8 +333,7 @@ async fn test_cat_file_pretty_blob() {
     assert_eq!(stdout, "Hello, Libra!\n", "Blob content should match");
 
     // cat-file -t the blob should return "blob"
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-t", blob_hash])
         .output()
         .unwrap();
@@ -360,8 +341,7 @@ async fn test_cat_file_pretty_blob() {
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "blob");
 
     // cat-file -s the blob should be 14 bytes ("Hello, Libra!\n" = 14)
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-s", blob_hash])
         .output()
         .unwrap();
@@ -380,8 +360,7 @@ async fn test_cat_file_panic_handling() {
 
     // Test that the command reports a structured invalid-target error rather than panicking
     // when accessing a non-existent object in a valid repository.
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", "0000000000000000000000000000000000000000"])
         .output()
         .expect("Failed to execute cat-file");
@@ -398,8 +377,7 @@ async fn test_cat_file_json_invalid_object_returns_cli_003() {
     let temp_dir = init_temp_repo();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args([
             "cat-file",
             "-p",
@@ -428,8 +406,7 @@ async fn test_cat_file_exist_check() {
     create_commit(temp_path, "f.txt", "data", "commit");
 
     // HEAD exists
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-e", "HEAD"])
         .output()
         .expect("Failed to execute cat-file -e");
@@ -444,8 +421,7 @@ async fn test_cat_file_exist_check() {
     );
 
     // Non-existent hash
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-e", "0000000000000000000000000000000000000000"])
         .output()
         .expect("Failed to execute cat-file -e");
@@ -464,8 +440,7 @@ async fn test_cat_file_mutual_exclusion() {
     let temp_dir = init_temp_repo();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-t", "-s", "HEAD"])
         .output()
         .expect("Failed to execute cat-file");
@@ -488,23 +463,20 @@ async fn test_cat_file_tree_multiple_files() {
     std::fs::write(temp_path.join("a.txt"), "aaa\n").unwrap();
     std::fs::write(temp_path.join("b.txt"), "bbb\n").unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["add", "."])
         .output()
         .unwrap();
     assert!(output.status.success());
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["commit", "-m", "two files", "--no-verify"])
         .output()
         .unwrap();
     assert!(output.status.success());
 
     // Get tree hash
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", "HEAD"])
         .output()
         .unwrap();
@@ -518,8 +490,7 @@ async fn test_cat_file_tree_multiple_files() {
         .trim();
 
     // Pretty-print tree
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", tree_hash])
         .output()
         .unwrap();
@@ -539,8 +510,7 @@ async fn test_cat_file_nonexistent_ref() {
     configure_user_identity(temp_path);
     create_commit(temp_path, "f.txt", "data", "commit");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-t", "nonexistent-branch"])
         .output()
         .expect("Failed to execute cat-file");
@@ -561,8 +531,7 @@ async fn test_cat_file_ai_list_types_empty() {
     let temp_dir = init_temp_repo();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "--ai-list-types"])
         .output()
         .expect("Failed to execute cat-file --ai-list-types");
@@ -587,8 +556,7 @@ async fn test_cat_file_ai_list_empty_type() {
     let temp_dir = init_temp_repo();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "--ai-list", "intent"])
         .output()
         .expect("Failed to execute cat-file --ai-list");
@@ -612,8 +580,7 @@ async fn test_cat_file_ai_list_invalid_type() {
     let temp_dir = init_temp_repo();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "--ai-list", "foobar"])
         .output()
         .expect("Failed to execute cat-file --ai-list");
@@ -635,8 +602,7 @@ async fn test_cat_file_ai_list_invalid_type_json_returns_cli_003() {
     let temp_dir = init_temp_repo();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "--ai-list", "foobar", "--json"])
         .output()
         .expect("Failed to execute cat-file");
@@ -654,8 +620,7 @@ async fn test_cat_file_json_pretty_print_io_read_failed_when_object_body_corrupt
     configure_user_identity(temp_path);
     create_commit(temp_path, "hello.txt", "hello world\n", "first commit");
 
-    let head_output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let head_output = libra_command(temp_path)
         .args(["rev-parse", "HEAD"])
         .output()
         .expect("Failed to execute rev-parse");
@@ -693,8 +658,7 @@ async fn test_cat_file_json_pretty_print_io_read_failed_when_object_body_corrupt
         .expect("Failed to finish corrupted commit object encoding");
     std::fs::write(&object_path, encoded).expect("Failed to write corrupted commit object");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "-p", &head, "--json"])
         .output()
         .expect("Failed to execute cat-file");
@@ -710,8 +674,7 @@ async fn test_cat_file_ai_nonexistent_uuid() {
     let temp_dir = init_temp_repo();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "--ai", "00000000-0000-0000-0000-000000000000"])
         .output()
         .expect("Failed to execute cat-file --ai");
@@ -734,8 +697,7 @@ async fn test_cat_file_ai_type_nonexistent() {
     let temp_dir = init_temp_repo();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args([
             "cat-file",
             "--ai-type",
@@ -756,8 +718,7 @@ async fn test_cat_file_ai_git_mutual_exclusion() {
     let temp_dir = init_temp_repo();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp_path)
+    let output = libra_command(temp_path)
         .args(["cat-file", "--ai-list-types", "-t", "HEAD"])
         .output()
         .expect("Failed to execute cat-file");
@@ -773,8 +734,7 @@ async fn test_cat_file_ai_git_mutual_exclusion() {
 fn test_cat_file_cli_outside_repository_returns_fatal_128() {
     let temp = tempfile::tempdir().unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_libra"))
-        .current_dir(temp.path())
+    let output = libra_command(temp.path())
         .args(["cat-file", "-t", "HEAD"])
         .output()
         .expect("Failed to execute cat-file");

--- a/tests/command/config_test.rs
+++ b/tests/command/config_test.rs
@@ -298,6 +298,9 @@ async fn test_config_get_all_with_default() {
 
     // set the current working directory to the temporary path
     let _guard = test::ChangeDirGuard::new(temp_path.path());
+    let global_db_dir = tempdir().unwrap();
+    let _scoped =
+        ScopedConfigPathGuard::new(&global_db_dir.path().join("global_config_get_all.db"));
 
     let result = exec_async(vec!["config", "--get-all", "-d", "erasernoob", "user.name"]).await;
     assert!(result.is_ok());

--- a/tests/command/mod.rs
+++ b/tests/command/mod.rs
@@ -86,6 +86,12 @@ fn base_libra_command(args: &[&str], cwd: &Path) -> Command {
     command
 }
 
+/// Build a Libra command with the same isolated process environment as
+/// [`run_libra_command`], leaving arguments for the caller to append.
+fn libra_command(cwd: &Path) -> Command {
+    base_libra_command(&[], cwd)
+}
+
 /// Run the Libra binary with an isolated HOME so host config never leaks into tests.
 fn run_libra_command(args: &[&str], cwd: &Path) -> Output {
     base_libra_command(args, cwd)

--- a/tests/command/push_error_test.rs
+++ b/tests/command/push_error_test.rs
@@ -131,7 +131,7 @@ fn test_push_invalid_refspec_returns_cli_invalid_arguments() {
         repo.path(),
     );
 
-    let output = run_libra_command(&["push", "origin", ":main"], repo.path());
+    let output = run_libra_command(&["push", "origin", "main:"], repo.path());
     let (_stderr, report) = parse_cli_error_stderr(&output.stderr);
 
     assert_eq!(output.status.code(), Some(129));

--- a/tests/command/switch_json_test.rs
+++ b/tests/command/switch_json_test.rs
@@ -175,6 +175,11 @@ fn json_schema_has_all_fields() {
 #[serial]
 async fn json_switch_track_has_tracking_fields() {
     let repo = create_committed_repo_via_cli();
+    let remote = run_libra_command(
+        &["remote", "add", "origin", "https://example.com/repo.git"],
+        repo.path(),
+    );
+    assert_cli_success(&remote, "remote add origin");
     let _guard = ChangeDirGuard::new(repo.path());
 
     let head = Head::current_commit().await.unwrap();

--- a/tests/command/switch_test.rs
+++ b/tests/command/switch_test.rs
@@ -109,6 +109,11 @@ fn test_switch_json_create_output_reports_new_branch() {
 #[serial]
 async fn test_switch_json_track_output_stays_clean() {
     let repo = create_committed_repo_via_cli();
+    let remote = run_libra_command(
+        &["remote", "add", "origin", "https://example.com/repo.git"],
+        repo.path(),
+    );
+    assert_cli_success(&remote, "remote add origin");
     let _guard = ChangeDirGuard::new(repo.path());
 
     let head = Head::current_commit().await.unwrap();
@@ -141,6 +146,11 @@ async fn test_switch_json_track_output_stays_clean() {
 #[serial]
 async fn test_switch_track_human_output_keeps_tracking_message() {
     let repo = create_committed_repo_via_cli();
+    let remote = run_libra_command(
+        &["remote", "add", "origin", "https://example.com/repo.git"],
+        repo.path(),
+    );
+    assert_cli_success(&remote, "remote add origin");
     let _guard = ChangeDirGuard::new(repo.path());
 
     let head = Head::current_commit().await.unwrap();
@@ -377,6 +387,11 @@ async fn test_switch_track_sets_upstream() {
     let temp_path = tempdir().unwrap();
     test::setup_with_new_libra_in(temp_path.path()).await;
     let _guard = ChangeDirGuard::new(temp_path.path());
+    let remote = run_libra_command(
+        &["remote", "add", "origin", "https://example.com/repo.git"],
+        temp_path.path(),
+    );
+    assert_cli_success(&remote, "remote add origin");
 
     let args = CommitArgs {
         message: Some("base".to_string()),

--- a/tests/e2e_mcp_flow.rs
+++ b/tests/e2e_mcp_flow.rs
@@ -168,6 +168,9 @@ async fn test_e2e_mcp_flow() {
 
     println!("Starting server on MCP port {mcp_port}, Web port {web_port}");
 
+    // This flow exercises MCP task/resource endpoints and never sends a model
+    // prompt. Keep startup hermetic by satisfying Gemini bootstrap with an
+    // isolated test-only key instead of relying on CI secrets.
     let mut child = Command::new(&libra_bin)
         .args([
             "code",
@@ -181,6 +184,7 @@ async fn test_e2e_mcp_flow() {
         .env("HOME", &home_dir)
         .env("XDG_CONFIG_HOME", &config_home)
         .env("USERPROFILE", &home_dir)
+        .env("GEMINI_API_KEY", "test-only-not-used")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()


### PR DESCRIPTION
## Summary

Stabilize the CI failures seen after rebasing onto the latest `main`, covering Linux sandbox setup, command integration tests, docs-backed UI tests, bundled seccomp policy compilation, command docs example-section coverage, x86 raw-I/O denylist coverage, atomic first-launch seccomp policy materialization, and hermetic MCP smoke-test startup.

- make Linux sandbox tests deterministic by opting into `bwrap` only through explicit `LIBRA_BWRAP_BINARY`, scoping the seccomp pre-exec hook to the transformed built-in `bwrap` command, and restoring seccomp env in tests
- allow current-repo local config lookups to fall back to global config/vault when the cwd is not a Libra repo, and surface typed object-load failures outside a repo instead of panicking
- run `cat-file` command tests through the shared isolated CLI test environment so stale runner global config DBs cannot leak warnings into stderr
- validate explicit push refspec/source errors before remote discovery so CLI/JSON output reports `LBR-CLI-002` / `LBR-CLI-003` instead of `LBR-NET-001`
- seed `switch --track` fixtures with a real `origin` remote now that upstream setup validates configured remotes
- make `internal::head` regression tests open the temp repo DB by explicit path instead of resolving it from the process cwd
- embed the authoritative local TUI control doc with `include_str!` so `code_ui` tests do not depend on CI cwd layout
- convert `template/seccomp-default.json` to the strict `seccompiler` JSON schema, retain x86_64 `iopl` / `ioperm` raw I/O denies, normalize unsupported syscall names before aarch64 compilation, and write generated BPF policies via temp-file + atomic persist
- gate macOS-only `worktree-fuse` helpers behind `target_os = "macos"` so Linux clippy stays warning-free
- add canonical `libra pull` common-command examples so the command docs examples guard passes
- start the MCP e2e server with an isolated test-only Gemini key so the protocol smoke test no longer depends on CI provider secrets; the flow does not issue model prompts

## Test plan

- [x] `cargo fmt --check`
- [x] `LIBRA_SKIP_WEB_BUILD=1 RUSTUP_TOOLCHAIN=stable cargo test --lib` (3231 passed)
- [x] `LIBRA_SKIP_WEB_BUILD=1 RUSTUP_TOOLCHAIN=stable cargo test --lib internal::ai::sandbox::seccomp_compile::tests -- --nocapture` (5 passed)
- [x] `LIBRA_SKIP_WEB_BUILD=1 RUSTUP_TOOLCHAIN=stable cargo test --lib internal::ai::web::code_ui::tests::code_ui_error_code_listing_matches_authoritative_doc -- --nocapture` (1 passed)
- [x] targeted `command_test` filters for the latest `cat-file`, `config`, `push`, and `switch --track` CI failures (10/10 passed)
- [x] `LIBRA_SKIP_WEB_BUILD=1 RUSTUP_TOOLCHAIN=stable cargo test --test compat_command_docs_examples_section -- --nocapture` (1 passed)
- [x] `LIBRA_SKIP_WEB_BUILD=1 RUSTUP_TOOLCHAIN=stable cargo test --test e2e_mcp_flow -- --nocapture` (1 passed)
- [x] `LIBRA_SKIP_WEB_BUILD=1 RUSTUP_TOOLCHAIN=stable cargo check --all-targets --all-features`
- [x] `LIBRA_SKIP_WEB_BUILD=1 RUSTUP_TOOLCHAIN=stable cargo clippy --all-targets --all-features -- -D warnings`
- [x] `LIBRA_SKIP_WEB_BUILD=1 RUSTUP_TOOLCHAIN=stable cargo clippy --test e2e_mcp_flow -- -D warnings`
