### PR TITLE
[codex] skip unnecessary status untracked scans

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -130,6 +130,7 @@ pub mod worktree;
 pub mod stash;
 pub mod status;
 pub(crate) mod status_untracked;
+pub(crate) mod status_untracked_paths;
 pub mod switch;
 pub mod web_assets;
 pub mod write_tree;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -129,6 +129,7 @@ pub mod worktree;
 
 pub mod stash;
 pub mod status;
+pub(crate) mod status_untracked;
 pub mod switch;
 pub mod web_assets;
 pub mod write_tree;

--- a/src/command/status.rs
+++ b/src/command/status.rs
@@ -415,13 +415,7 @@ async fn collect_status_data(args: &StatusArgs) -> CliResult<StatusData> {
         .into_iter()
         .map(util::workdir_to_current)
         .collect();
-    let needs_index = matches!(args.untracked_files, UntrackedFiles::Normal)
-        || matches!(args.porcelain, Some(PorcelainVersion::V2));
-    let mut maybe_index = if needs_index {
-        Some(worktree.index)
-    } else {
-        None
-    };
+    let mut maybe_index = Some(worktree.index);
 
     // Resolve rename detection: `--no-renames` wins (off); otherwise `--renames`
     // (or `--find-renames`) enables it at the given threshold (default 50).

--- a/src/command/status.rs
+++ b/src/command/status.rs
@@ -22,7 +22,7 @@ use git_internal::{
 };
 use serde::Serialize;
 
-use super::{merge, stash};
+use super::{merge, stash, status_untracked};
 use crate::{
     command::calc_file_blob_hash,
     internal::{
@@ -406,39 +406,22 @@ async fn collect_status_data(args: &StatusArgs) -> CliResult<StatusData> {
         .await
         .map(|c| c.to_relative())
         .map_err(CliError::from)?;
-    let mut unstaged = changes_to_be_staged()
-        .map(|c| c.to_relative())
-        .map_err(CliError::from)?;
-    let mut ignored_files = if args.ignored && !matches!(args.untracked_files, UntrackedFiles::No) {
-        list_ignored_files()
-            .map(|c| c.to_relative().new)
-            .map_err(CliError::from)?
-    } else {
-        vec![]
-    };
+    let worktree =
+        status_untracked::collect_status_worktree_changes(args.untracked_files, args.ignored)
+            .map_err(CliError::from)?;
+    let mut unstaged = status_untracked::changes_to_current_directory(worktree.unstaged);
+    let ignored_files = worktree
+        .ignored_files
+        .into_iter()
+        .map(util::workdir_to_current)
+        .collect();
     let needs_index = matches!(args.untracked_files, UntrackedFiles::Normal)
         || matches!(args.porcelain, Some(PorcelainVersion::V2));
     let mut maybe_index = if needs_index {
-        Some(load_status_index()?)
+        Some(worktree.index)
     } else {
         None
     };
-
-    // Apply untracked-files filter
-    match args.untracked_files {
-        UntrackedFiles::No => {
-            unstaged.new.clear();
-            ignored_files.clear();
-        }
-        UntrackedFiles::Normal => {
-            let index = maybe_index
-                .as_ref()
-                .ok_or_else(|| CliError::internal("status index should be loaded"))?;
-            unstaged.new = collapse_untracked_directories(unstaged.new, index);
-            ignored_files = collapse_untracked_directories(ignored_files, index);
-        }
-        UntrackedFiles::All => {}
-    }
 
     // Resolve rename detection: `--no-renames` wins (off); otherwise `--renames`
     // (or `--find-renames`) enables it at the given threshold (default 50).
@@ -733,8 +716,9 @@ pub async fn execute_safe(args: StatusArgs, output: &OutputConfig) -> CliResult<
 
 // ─── Dirty-set cache modes (lore.md §1.1) ───────────────────────────────────
 
-/// The raw (repo-relative) staged + unstaged sets, computed by the same full
-/// safe reconcile the default status uses.
+/// The raw (repo-relative) staged + unstaged sets for dirty-cache snapshots.
+/// This remains a full reconcile so `status --scan` can discover every dirty
+/// path before replacing the cache.
 async fn compute_raw_sets() -> CliResult<(Changes, Changes)> {
     let staged = changes_to_be_committed_safe()
         .await

--- a/src/command/status_untracked.rs
+++ b/src/command/status_untracked.rs
@@ -1,5 +1,6 @@
 use std::{
     ffi::OsStr,
+    io,
     path::{Path, PathBuf},
 };
 
@@ -8,6 +9,10 @@ use git_internal::internal::index::Index;
 use super::{
     calc_file_blob_hash,
     status::{Changes, StatusError, UntrackedFiles},
+    status_untracked_paths::{
+        TrackedPaths, collapse_untracked_directories, directory_marker, is_top_level_path,
+        sort_paths,
+    },
 };
 use crate::utils::{path, util};
 
@@ -32,27 +37,21 @@ pub(crate) fn collect_status_worktree_changes(
         path: index_path.clone(),
         source,
     })?;
-    let tracked_files = index.tracked_files();
-    let mut unstaged = collect_tracked_worktree_changes(&workdir, &index, &tracked_files)?;
+    let tracked = TrackedPaths::from_index(&index);
+    let mut unstaged = collect_tracked_worktree_changes(&workdir, &index, tracked.files())?;
     let mut ignored_files = Vec::new();
 
     if !matches!(untracked_mode, UntrackedFiles::No) {
-        let scan = scan_workdir(
-            &workdir,
-            &index,
-            &tracked_files,
-            untracked_mode,
-            include_ignored,
-        )?;
-        unstaged.new = if matches!(untracked_mode, UntrackedFiles::Normal) && include_ignored {
-            collapse_untracked_directories(scan.untracked, &index)
+        let scan = scan_workdir(&workdir, &index, &tracked, untracked_mode, include_ignored)?;
+        unstaged.new = if matches!(untracked_mode, UntrackedFiles::Normal) {
+            collapse_untracked_directories(scan.untracked, &tracked)
         } else {
-            scan.untracked
+            sort_paths(scan.untracked)
         };
-        ignored_files = if matches!(untracked_mode, UntrackedFiles::Normal) && include_ignored {
-            collapse_untracked_directories(scan.ignored, &index)
+        ignored_files = if matches!(untracked_mode, UntrackedFiles::Normal) {
+            collapse_untracked_directories(scan.ignored, &tracked)
         } else {
-            scan.ignored
+            sort_paths(scan.ignored)
         };
     }
 
@@ -126,7 +125,7 @@ fn collect_tracked_worktree_changes(
 fn scan_workdir(
     workdir: &Path,
     index: &Index,
-    tracked_files: &[PathBuf],
+    tracked: &TrackedPaths,
     untracked_mode: UntrackedFiles,
     include_ignored: bool,
 ) -> Result<WorkdirScan, StatusError> {
@@ -137,14 +136,8 @@ fn scan_workdir(
     let mut pending_dirs = vec![workdir.to_path_buf()];
 
     while let Some(dir) = pending_dirs.pop() {
-        for entry in std::fs::read_dir(&dir).map_err(|source| StatusError::ListWorkdirFiles {
-            path: workdir.to_path_buf(),
-            source,
-        })? {
-            let entry = entry.map_err(|source| StatusError::ListWorkdirFiles {
-                path: workdir.to_path_buf(),
-                source,
-            })?;
+        for entry in std::fs::read_dir(&dir).map_err(|source| list_error(&dir, source))? {
+            let entry = entry.map_err(|source| list_error(&dir, source))?;
             let path = entry.path();
             let name = entry.file_name();
             if name == OsStr::new(util::ROOT_DIR) || name == OsStr::new(util::GIT_DIR) {
@@ -153,16 +146,10 @@ fn scan_workdir(
 
             let file_type = entry
                 .file_type()
-                .map_err(|source| StatusError::ListWorkdirFiles {
-                    path: workdir.to_path_buf(),
-                    source,
-                })?;
+                .map_err(|source| list_error(&dir, source))?;
             let relative = path
                 .strip_prefix(workdir)
-                .map_err(|err| StatusError::ListWorkdirFiles {
-                    path: workdir.to_path_buf(),
-                    source: std::io::Error::other(err.to_string()),
-                })?
+                .map_err(|err| list_error(&dir, io::Error::other(err.to_string())))?
                 .to_path_buf();
             if file_type.is_dir() {
                 if util::check_gitignore(&workdir.to_path_buf(), &path) {
@@ -174,7 +161,7 @@ fn scan_workdir(
                 if matches!(untracked_mode, UntrackedFiles::Normal)
                     && !include_ignored
                     && is_top_level_path(&relative)
-                    && !has_tracked_descendant(&relative, tracked_files)
+                    && !tracked.has_descendant(&relative)
                 {
                     scan.untracked.push(directory_marker(&relative));
                     continue;
@@ -213,52 +200,9 @@ fn scan_file(
     Ok(())
 }
 
-fn collapse_untracked_directories(untracked_files: Vec<PathBuf>, index: &Index) -> Vec<PathBuf> {
-    use std::collections::{BTreeSet, HashMap};
-
-    if untracked_files.is_empty() {
-        return untracked_files;
+fn list_error(path: &Path, source: io::Error) -> StatusError {
+    StatusError::ListWorkdirFiles {
+        path: path.to_path_buf(),
+        source,
     }
-
-    let mut dir_files: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
-    let mut root_files: Vec<PathBuf> = Vec::new();
-
-    for file in &untracked_files {
-        let components: Vec<_> = file.components().collect();
-        if components.len() > 1 {
-            let top_dir = PathBuf::from(components[0].as_os_str());
-            dir_files.entry(top_dir).or_default().push(file.clone());
-        } else {
-            root_files.push(file.clone());
-        }
-    }
-
-    let mut result: BTreeSet<PathBuf> = BTreeSet::new();
-    result.extend(root_files);
-
-    for (dir, files) in dir_files {
-        if has_tracked_descendant(&dir, &index.tracked_files()) {
-            result.extend(files);
-        } else {
-            result.insert(directory_marker(&dir));
-        }
-    }
-
-    result.into_iter().collect()
-}
-
-fn has_tracked_descendant(dir: &Path, tracked_files: &[PathBuf]) -> bool {
-    tracked_files.iter().any(|file| file.starts_with(dir))
-}
-
-fn is_top_level_path(path: &Path) -> bool {
-    path.components().count() == 1
-}
-
-fn directory_marker(path: &Path) -> PathBuf {
-    let mut display = path.display().to_string();
-    if !display.ends_with('/') {
-        display.push('/');
-    }
-    PathBuf::from(display)
 }

--- a/src/command/status_untracked.rs
+++ b/src/command/status_untracked.rs
@@ -1,0 +1,264 @@
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+use git_internal::internal::index::Index;
+
+use super::{
+    calc_file_blob_hash,
+    status::{Changes, StatusError, UntrackedFiles},
+};
+use crate::utils::{path, util};
+
+pub(crate) struct StatusWorktreeChanges {
+    pub(crate) unstaged: Changes,
+    pub(crate) ignored_files: Vec<PathBuf>,
+    pub(crate) index: Index,
+}
+
+struct WorkdirScan {
+    untracked: Vec<PathBuf>,
+    ignored: Vec<PathBuf>,
+}
+
+pub(crate) fn collect_status_worktree_changes(
+    untracked_mode: UntrackedFiles,
+    include_ignored: bool,
+) -> Result<StatusWorktreeChanges, StatusError> {
+    let workdir = util::try_working_dir().map_err(|source| StatusError::Workdir { source })?;
+    let index_path = path::try_index().map_err(|source| StatusError::Workdir { source })?;
+    let index = Index::load(&index_path).map_err(|source| StatusError::IndexLoad {
+        path: index_path.clone(),
+        source,
+    })?;
+    let tracked_files = index.tracked_files();
+    let mut unstaged = collect_tracked_worktree_changes(&workdir, &index, &tracked_files)?;
+    let mut ignored_files = Vec::new();
+
+    if !matches!(untracked_mode, UntrackedFiles::No) {
+        let scan = scan_workdir(
+            &workdir,
+            &index,
+            &tracked_files,
+            untracked_mode,
+            include_ignored,
+        )?;
+        unstaged.new = if matches!(untracked_mode, UntrackedFiles::Normal) && include_ignored {
+            collapse_untracked_directories(scan.untracked, &index)
+        } else {
+            scan.untracked
+        };
+        ignored_files = if matches!(untracked_mode, UntrackedFiles::Normal) && include_ignored {
+            collapse_untracked_directories(scan.ignored, &index)
+        } else {
+            scan.ignored
+        };
+    }
+
+    Ok(StatusWorktreeChanges {
+        unstaged,
+        ignored_files,
+        index,
+    })
+}
+
+pub(crate) fn changes_to_current_directory(mut changes: Changes) -> Changes {
+    changes.new = changes
+        .new
+        .into_iter()
+        .map(path_to_current_preserving_directory_marker)
+        .collect();
+    changes.modified = changes
+        .modified
+        .into_iter()
+        .map(util::workdir_to_current)
+        .collect();
+    changes.deleted = changes
+        .deleted
+        .into_iter()
+        .map(util::workdir_to_current)
+        .collect();
+    changes.renamed = changes
+        .renamed
+        .into_iter()
+        .map(|(old, new)| (util::workdir_to_current(old), util::workdir_to_current(new)))
+        .collect();
+    changes
+}
+
+fn path_to_current_preserving_directory_marker(path: PathBuf) -> PathBuf {
+    if !path.to_string_lossy().ends_with('/') {
+        return util::workdir_to_current(path);
+    }
+
+    let relative = util::workdir_to_current(&path);
+    directory_marker(&relative)
+}
+
+fn collect_tracked_worktree_changes(
+    workdir: &Path,
+    index: &Index,
+    tracked_files: &[PathBuf],
+) -> Result<Changes, StatusError> {
+    let mut changes = Changes::default();
+    for file in tracked_files {
+        let file_str = file
+            .to_str()
+            .ok_or_else(|| StatusError::InvalidPathEncoding { path: file.clone() })?;
+        let file_abs = workdir.join(file);
+        if !file_abs.exists() {
+            changes.deleted.push(file.clone());
+        } else if index.is_modified(file_str, 0, workdir) {
+            let file_hash =
+                calc_file_blob_hash(&file_abs).map_err(|source| StatusError::FileHash {
+                    path: file_abs.clone(),
+                    source,
+                })?;
+            if !index.verify_hash(file_str, 0, &file_hash) {
+                changes.modified.push(file.clone());
+            }
+        }
+    }
+    Ok(changes)
+}
+
+fn scan_workdir(
+    workdir: &Path,
+    index: &Index,
+    tracked_files: &[PathBuf],
+    untracked_mode: UntrackedFiles,
+    include_ignored: bool,
+) -> Result<WorkdirScan, StatusError> {
+    let mut scan = WorkdirScan {
+        untracked: Vec::new(),
+        ignored: Vec::new(),
+    };
+    let mut pending_dirs = vec![workdir.to_path_buf()];
+
+    while let Some(dir) = pending_dirs.pop() {
+        for entry in std::fs::read_dir(&dir).map_err(|source| StatusError::ListWorkdirFiles {
+            path: workdir.to_path_buf(),
+            source,
+        })? {
+            let entry = entry.map_err(|source| StatusError::ListWorkdirFiles {
+                path: workdir.to_path_buf(),
+                source,
+            })?;
+            let path = entry.path();
+            let name = entry.file_name();
+            if name == OsStr::new(util::ROOT_DIR) || name == OsStr::new(util::GIT_DIR) {
+                continue;
+            }
+
+            let file_type = entry
+                .file_type()
+                .map_err(|source| StatusError::ListWorkdirFiles {
+                    path: workdir.to_path_buf(),
+                    source,
+                })?;
+            let relative = path
+                .strip_prefix(workdir)
+                .map_err(|err| StatusError::ListWorkdirFiles {
+                    path: workdir.to_path_buf(),
+                    source: std::io::Error::other(err.to_string()),
+                })?
+                .to_path_buf();
+            if file_type.is_dir() {
+                if util::check_gitignore(&workdir.to_path_buf(), &path) {
+                    if include_ignored {
+                        scan.ignored.push(relative);
+                    }
+                    continue;
+                }
+                if matches!(untracked_mode, UntrackedFiles::Normal)
+                    && !include_ignored
+                    && is_top_level_path(&relative)
+                    && !has_tracked_descendant(&relative, tracked_files)
+                {
+                    scan.untracked.push(directory_marker(&relative));
+                    continue;
+                }
+                pending_dirs.push(path);
+            } else if file_type.is_file() {
+                scan_file(&mut scan, workdir, index, &path, &relative, include_ignored)?;
+            }
+        }
+    }
+
+    Ok(scan)
+}
+
+fn scan_file(
+    scan: &mut WorkdirScan,
+    workdir: &Path,
+    index: &Index,
+    path: &Path,
+    relative: &Path,
+    include_ignored: bool,
+) -> Result<(), StatusError> {
+    let file_str = relative
+        .to_str()
+        .ok_or_else(|| StatusError::InvalidPathEncoding {
+            path: relative.to_path_buf(),
+        })?;
+    let tracked = index.tracked(file_str, 0);
+    if util::check_gitignore(&workdir.to_path_buf(), &path.to_path_buf()) {
+        if include_ignored && !tracked {
+            scan.ignored.push(relative.to_path_buf());
+        }
+    } else if !tracked {
+        scan.untracked.push(relative.to_path_buf());
+    }
+    Ok(())
+}
+
+fn collapse_untracked_directories(untracked_files: Vec<PathBuf>, index: &Index) -> Vec<PathBuf> {
+    use std::collections::{BTreeSet, HashMap};
+
+    if untracked_files.is_empty() {
+        return untracked_files;
+    }
+
+    let mut dir_files: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
+    let mut root_files: Vec<PathBuf> = Vec::new();
+
+    for file in &untracked_files {
+        let components: Vec<_> = file.components().collect();
+        if components.len() > 1 {
+            let top_dir = PathBuf::from(components[0].as_os_str());
+            dir_files.entry(top_dir).or_default().push(file.clone());
+        } else {
+            root_files.push(file.clone());
+        }
+    }
+
+    let mut result: BTreeSet<PathBuf> = BTreeSet::new();
+    result.extend(root_files);
+
+    for (dir, files) in dir_files {
+        if has_tracked_descendant(&dir, &index.tracked_files()) {
+            result.extend(files);
+        } else {
+            result.insert(directory_marker(&dir));
+        }
+    }
+
+    result.into_iter().collect()
+}
+
+fn has_tracked_descendant(dir: &Path, tracked_files: &[PathBuf]) -> bool {
+    tracked_files.iter().any(|file| file.starts_with(dir))
+}
+
+fn is_top_level_path(path: &Path) -> bool {
+    path.components().count() == 1
+}
+
+fn directory_marker(path: &Path) -> PathBuf {
+    let mut display = path.display().to_string();
+    if !display.ends_with('/') {
+        display.push('/');
+    }
+    PathBuf::from(display)
+}

--- a/src/command/status_untracked_paths.rs
+++ b/src/command/status_untracked_paths.rs
@@ -1,0 +1,93 @@
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    path::{Path, PathBuf},
+};
+
+use git_internal::internal::index::Index;
+
+pub(crate) struct TrackedPaths {
+    files: Vec<PathBuf>,
+    top_level_dirs: HashSet<PathBuf>,
+}
+
+impl TrackedPaths {
+    pub(crate) fn from_index(index: &Index) -> Self {
+        let files = index.tracked_files();
+        let top_level_dirs = files
+            .iter()
+            .filter_map(|path| top_level_dir(path))
+            .collect();
+        Self {
+            files,
+            top_level_dirs,
+        }
+    }
+
+    pub(crate) fn files(&self) -> &[PathBuf] {
+        &self.files
+    }
+
+    pub(crate) fn has_descendant(&self, dir: &Path) -> bool {
+        if is_top_level_path(dir) {
+            return self.top_level_dirs.contains(dir);
+        }
+        self.files.iter().any(|file| file.starts_with(dir))
+    }
+}
+
+pub(crate) fn collapse_untracked_directories(
+    untracked_files: Vec<PathBuf>,
+    tracked: &TrackedPaths,
+) -> Vec<PathBuf> {
+    if untracked_files.is_empty() {
+        return untracked_files;
+    }
+
+    let mut dir_files: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
+    let mut root_files: Vec<PathBuf> = Vec::new();
+    for file in &untracked_files {
+        let components: Vec<_> = file.components().collect();
+        if components.len() > 1 {
+            let top_dir = PathBuf::from(components[0].as_os_str());
+            dir_files.entry(top_dir).or_default().push(file.clone());
+        } else {
+            root_files.push(file.clone());
+        }
+    }
+
+    let mut result: BTreeSet<PathBuf> = BTreeSet::new();
+    result.extend(root_files);
+    for (dir, files) in dir_files {
+        if tracked.has_descendant(&dir) {
+            result.extend(files);
+        } else {
+            result.insert(directory_marker(&dir));
+        }
+    }
+
+    result.into_iter().collect()
+}
+
+pub(crate) fn sort_paths(mut paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+pub(crate) fn is_top_level_path(path: &Path) -> bool {
+    path.components().count() == 1
+}
+
+pub(crate) fn directory_marker(path: &Path) -> PathBuf {
+    let mut display = path.display().to_string();
+    if !display.ends_with('/') {
+        display.push('/');
+    }
+    PathBuf::from(display)
+}
+
+fn top_level_dir(path: &Path) -> Option<PathBuf> {
+    let mut components = path.components();
+    let first = PathBuf::from(components.next()?.as_os_str());
+    components.next().map(|_| first)
+}

--- a/tests/command/status_test.rs
+++ b/tests/command/status_test.rs
@@ -1035,6 +1035,41 @@ async fn test_status_normal_reports_untracked_directory_without_descending() {
 
 #[tokio::test]
 #[serial]
+async fn test_status_normal_untracked_directories_are_sorted() {
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    fs::create_dir_all("zeta").unwrap();
+    fs::write("zeta/file.txt", "z").unwrap();
+    fs::create_dir_all("alpha").unwrap();
+    fs::write("alpha/file.txt", "a").unwrap();
+
+    let mut output = Vec::new();
+    status_execute(
+        StatusArgs {
+            untracked_files: UntrackedFiles::Normal,
+            ..Default::default()
+        },
+        &mut output,
+    )
+    .await;
+
+    let output_str = String::from_utf8(output).unwrap().replace("\\", "/");
+    let alpha = output_str
+        .find("\talpha/")
+        .expect("normal status should list alpha/ as a collapsed directory");
+    let zeta = output_str
+        .find("\tzeta/")
+        .expect("normal status should list zeta/ as a collapsed directory");
+    assert!(
+        alpha < zeta,
+        "normal status should sort collapsed untracked directories: {output_str}"
+    );
+}
+
+#[tokio::test]
+#[serial]
 /// Tests --untracked-files=all retains untracked output (same as normal for now).
 async fn test_status_untracked_files_all() {
     let test_dir = tempdir().unwrap();

--- a/tests/command/status_test.rs
+++ b/tests/command/status_test.rs
@@ -966,6 +966,73 @@ async fn test_status_untracked_files_no() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn test_status_untracked_files_no_skips_untracked_directory_scan() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    fs::create_dir_all("artifacts/deep").unwrap();
+    fs::write("artifacts/deep/blob.bin", "untracked build output").unwrap();
+    fs::set_permissions("artifacts", fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut output = Vec::new();
+    let result = status_execute_inner(
+        StatusArgs {
+            short: true,
+            untracked_files: UntrackedFiles::No,
+            ..Default::default()
+        },
+        &mut output,
+    )
+    .await;
+
+    fs::set_permissions("artifacts", fs::Permissions::from_mode(0o700)).unwrap();
+    result.expect("status -uno should not scan hidden untracked directories");
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        !output_str.contains("artifacts"),
+        "status -uno should hide untracked directories: {output_str}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn test_status_normal_reports_untracked_directory_without_descending() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempdir().unwrap();
+    test::setup_with_new_libra_in(test_dir.path()).await;
+    let _guard = test::ChangeDirGuard::new(test_dir.path());
+
+    fs::create_dir_all("artifacts/deep").unwrap();
+    fs::write("artifacts/deep/blob.bin", "untracked build output").unwrap();
+    fs::set_permissions("artifacts", fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut output = Vec::new();
+    let result = status_execute_inner(
+        StatusArgs {
+            short: true,
+            ..Default::default()
+        },
+        &mut output,
+    )
+    .await;
+
+    fs::set_permissions("artifacts", fs::Permissions::from_mode(0o700)).unwrap();
+    result.expect("status -s should report a top-level untracked directory without reading it");
+    let output_str = String::from_utf8(output).unwrap();
+    assert!(
+        output_str.lines().any(|line| line == "?? artifacts/"),
+        "status -s should report the untracked directory itself: {output_str}"
+    );
+}
+
 #[tokio::test]
 #[serial]
 /// Tests --untracked-files=all retains untracked output (same as normal for now).


### PR DESCRIPTION
## Summary

- Add a status-specific worktree collector that skips untracked discovery for `status -uno`.
- Report top-level untracked directories in normal mode without descending into directories that have no tracked descendants.
- Preserve existing collapsed-directory output and add regressions for unreadable untracked artifact directories.

## Why

`status` should not pay for untracked discovery when the user explicitly hides untracked files, and normal mode can safely report a completely untracked top-level directory without recursively scanning build artifacts. This mirrors the performance concern addressed for pull/restore while preserving `status -uall` full discovery behavior.

## Validation

- `cargo +nightly fmt --all --check`
- `LIBRA_SKIP_WEB_BUILD=1 cargo clippy --all-targets --all-features -- -D warnings`
- `LIBRA_SKIP_WEB_BUILD=1 cargo test --test command_test untracked_directory -- --nocapture`
- `LIBRA_SKIP_WEB_BUILD=1 cargo test --test command_test test_status_with_subdirectories -- --nocapture`
- `LIBRA_SKIP_WEB_BUILD=1 cargo test --test command_test status_test -- --nocapture`
