### PR TITLE
chore: bump git-internal to 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ keyring = ["dep:keyring"]  # lore.md 2.7: OS-keyring auth backend (release build
 
 [dependencies]
 uuid = { version = "1.23.1", features = ["v4", "v5", "v7"] }
-git-internal = "0.8.1"
+git-internal = "0.8.2"
 anyhow = "1.0.102"
 byte-unit = "5.2.0"
 byteorder = "1.5.0"


### PR DESCRIPTION
﻿## Summary
- Bump Libra's `git-internal` dependency requirement from `0.8.1` to `0.8.2`.
- This is the release dependency follow-up for the WSL/v9fs index timestamp fix in `git-internal`.

## Notes
- `Cargo.lock` is intentionally not updated yet because `git-internal 0.8.2` is not available in the configured registry/mirror at PR creation time.
- After `git-internal 0.8.2` is published, run `cargo update -p git-internal --precise 0.8.2` and the normal Libra checks.

## Validation
- Attempted `cargo update -p git-internal --precise 0.8.2`; it currently fails because the version has not been published to the configured registry/mirror yet.
- The WSL/v9fs behavior was validated with the sibling local checkout before this release follow-up: `libra add tracked.txt` succeeds on `/mnt/d/code/rustpan`, where `stat` reports `Birth: -`.


Link: #425 