### PR TITLE
Fix Smart HTTP push framing

### DIFF
--- a/src/internal/protocol/https_client.rs
+++ b/src/internal/protocol/https_client.rs
@@ -4,7 +4,7 @@ use std::{io::Error as IoError, ops::Deref, sync::Mutex, time::Duration};
 
 use futures_util::{StreamExt, TryStreamExt};
 use git_internal::errors::GitError;
-use reqwest::{Body, RequestBuilder, Response, StatusCode, header::CONTENT_TYPE};
+use reqwest::{RequestBuilder, Response, StatusCode, header::CONTENT_TYPE};
 use url::Url;
 
 use super::{
@@ -464,10 +464,7 @@ impl HttpsClient {
         Ok(result)
     }
 
-    pub async fn send_pack<T: Into<Body> + Clone>(
-        &self,
-        data: T,
-    ) -> Result<Response, reqwest::Error> {
+    pub async fn send_pack(&self, data: bytes::Bytes) -> Result<Response, reqwest::Error> {
         // INVARIANT: "git-receive-pack" is a valid relative URL onto self.url.
         let receive_pack_url = self
             .url
@@ -477,6 +474,12 @@ impl HttpsClient {
             self.client
                 .post(receive_pack_url.clone())
                 .header(CONTENT_TYPE, "application/x-git-receive-pack-request")
+                .header(
+                    reqwest::header::ACCEPT,
+                    "application/x-git-receive-pack-result",
+                )
+                .header(reqwest::header::USER_AGENT, "git/2.43.0 libra")
+                .header(reqwest::header::CONTENT_LENGTH, data.len())
                 .body(data.clone())
         })
         .await


### PR DESCRIPTION
## What changed

- send Git-compatible `Accept` and `User-Agent` headers for Smart HTTP receive-pack requests
- use a concrete `Bytes` request body and set its exact `Content-Length`
- preserve retryable request bodies across Basic authentication attempts

## Why

Some Git-compatible gateways reject or proxy-fail Libra receive-pack POSTs when the request framing differs from native Git. Against a mega deployment this surfaced as `502 Bad Gateway`, while native `git push` succeeded.

## Impact

Libra Smart HTTP pushes now use deterministic request framing and headers compatible with native Git receive-pack endpoints.

## Validation

- `cargo fmt --check`
- built Libra 0.19.40 locally under WSL
- verified a Libra Smart HTTP push reached mega receive-pack successfully instead of returning 502
- verified the full push advanced to mega's repository policy/object-storage processing; remaining failures were server-side RustFS/S3 PUT errors