### PR TITLE
fix(upgrade): restore Windows release build

### DIFF
--- a/src/command/agent/import.rs
+++ b/src/command/agent/import.rs
@@ -799,7 +799,7 @@ fn discover_codex(since: Option<i64>, deadline: Instant) -> Result<Vec<Candidate
     return discover_codex_unix(&root, &directory, since, deadline);
     #[cfg(not(unix))]
     {
-        let pinned_root = root;
+        let pinned_root = root.clone();
         let mut scanned = 0usize;
         let mut candidates = Vec::new();
         for year in read_codex_discovery_directory(&pinned_root, deadline, &mut scanned)? {

--- a/src/internal/upgrade/lock.rs
+++ b/src/internal/upgrade/lock.rs
@@ -66,6 +66,7 @@ pub enum EntryKind {
     Other,
 }
 
+#[cfg(unix)]
 fn validate_entry_name(name: &str) -> Result<(), InstallDirError> {
     if name.is_empty() || name == "." || name == ".." || name.contains('/') || name.contains('\0') {
         return Err(InstallDirError::BadEntryName(name.to_string()));
@@ -421,6 +422,50 @@ impl InstallDir {
     /// §A.5: Windows (and any non-Unix target) does not enter the upgrade
     /// file path in R0.
     pub fn open_validated(_path: &Path) -> Result<Self, InstallDirError> {
+        Err(InstallDirError::UnsupportedPlatform)
+    }
+
+    /// The canonical directory path (diagnostics only).
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    // Keep the Unix-only upgrade callers type-checking on unsupported
+    // platforms while failing closed before any filesystem operation.
+    pub fn stat_entry(&self, _name: &str) -> Result<Option<EntryKind>, InstallDirError> {
+        Err(InstallDirError::UnsupportedPlatform)
+    }
+
+    pub fn read_file(&self, _name: &str) -> Result<Option<Vec<u8>>, InstallDirError> {
+        Err(InstallDirError::UnsupportedPlatform)
+    }
+
+    pub fn write_file_atomic(
+        &self,
+        _name: &str,
+        _bytes: &[u8],
+        _mode: u32,
+    ) -> Result<(), InstallDirError> {
+        Err(InstallDirError::UnsupportedPlatform)
+    }
+
+    pub fn rename_entry(&self, _from: &str, _to: &str) -> Result<(), InstallDirError> {
+        Err(InstallDirError::UnsupportedPlatform)
+    }
+
+    pub fn remove_file(&self, _name: &str) -> Result<bool, InstallDirError> {
+        Err(InstallDirError::UnsupportedPlatform)
+    }
+
+    pub fn fsync_dir(&self) -> Result<(), InstallDirError> {
+        Err(InstallDirError::UnsupportedPlatform)
+    }
+
+    pub fn try_lock(&self) -> Result<Option<UpgradeLock>, InstallDirError> {
+        Err(InstallDirError::UnsupportedPlatform)
+    }
+
+    pub fn lock_blocking(&self) -> Result<UpgradeLock, InstallDirError> {
         Err(InstallDirError::UnsupportedPlatform)
     }
 }


### PR DESCRIPTION
## Summary

- restore the non-Unix `InstallDir` API surface with fail-closed unsupported-platform errors, allowing Windows callers to compile without enabling Unix fd-relative upgrade operations
- avoid moving the agent-import root path in the Windows branch
- keep the Unix-only entry-name validator out of non-Unix builds

## Root Cause

The upgrade marker, transaction, and orchestrator modules compile on Windows, but `InstallDir` exposed only `open_validated` there. Their remaining method calls therefore failed with missing-method errors. Agent import also moved `root` into a Windows-only binding before a later borrow.

## Impact

Windows release builds now compile and retain the intended fail-closed behavior: auto-upgrade file operations remain unsupported outside Unix rather than falling back to path-based filesystem access.

## Validation

- `cargo +1.97.1-x86_64-pc-windows-msvc build --locked --release --features keyring --target x86_64-pc-windows-msvc` with the release workflow `RUSTFLAGS`
- `target\\x86_64-pc-windows-msvc\\release\\libra.exe --version`
- `cargo +1.97.1-x86_64-pc-windows-msvc build --locked --all-features`
- `cargo +nightly fmt --all --check`
- `pnpm --dir web lint`
- `pnpm --dir web build`

`cargo test --all` was also attempted on Windows. It is currently blocked by pre-existing Unix-only test code compiled without platform guards in `opencode_export.rs` and `utils/object.rs`; this is independent of this change and the release target builds successfully.
